### PR TITLE
Calling base.Dispose will call AudioFileClose which can write to the file

### DIFF
--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -1044,9 +1044,9 @@ namespace MonoMac.AudioToolbox {
 
 		protected override void Dispose (bool disposing)
 		{
+			base.Dispose (disposing);
 			if (gch.IsAllocated)
 				gch.Free ();
-			base.Dispose (disposing);
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]


### PR DESCRIPTION
Calling base.Dispose will call AudioFileClose which can write to the file, so we need to do our Dispose work before freeing the GC handle.
