### PR TITLE
Make GetCurrentTime output params out instead of ref

### DIFF
--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -431,9 +431,9 @@ namespace MonoMac.AudioToolbox {
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static AudioQueueStatus AudioQueueGetCurrentTime (IntPtr AQ, IntPtr timelineHandle, ref AudioTimeStamp time, ref bool discontinuty);
+		extern static AudioQueueStatus AudioQueueGetCurrentTime (IntPtr AQ, IntPtr timelineHandle, out AudioTimeStamp time, out bool discontinuty);
 
-		public AudioQueueStatus GetCurrentTime (AudioQueueTimeline timeline, ref AudioTimeStamp time, ref bool timelineDiscontinuty)
+		public AudioQueueStatus GetCurrentTime (AudioQueueTimeline timeline, out AudioTimeStamp time, out bool timelineDiscontinuty)
 		{
 			IntPtr arg;
 			if (timeline == null)
@@ -444,7 +444,7 @@ namespace MonoMac.AudioToolbox {
 					throw new ObjectDisposedException ("timeline");
 			}
 
-			return AudioQueueGetCurrentTime (handle, arg, ref time, ref timelineDiscontinuty);
+			return AudioQueueGetCurrentTime (handle, arg, out time, out timelineDiscontinuty);
 		}
 
 


### PR DESCRIPTION
According to docs: http://developer.apple.com/library/mac/#documentation/MusicAudio/Reference/AudioQueueReference/Reference/reference.html#//apple_ref/doc/uid/TP40005117 
these should be out params.