### PR TITLE
Allow AudioSource's to be opened with callbacks outside of the ctor.

### DIFF
--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -1083,6 +1083,11 @@ namespace MonoMac.AudioToolbox {
 		
 		public AudioSource (AudioFileType fileTypeHint) : base (true)
 		{
+			Open (fileTypeHint);
+		}
+		
+		protected void Open (AudioFileType fileTypeHint)
+		{
 			IntPtr h;
 
 			gch = GCHandle.Alloc (this);


### PR DESCRIPTION
Allow AudioSource's to be opened with callbacks outside of the ctor. This is different from Initialize which will create a new file.
