### PR TITLE
Add 'RangeValue' property to NSValue for MonoMac.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4154,6 +4154,9 @@ namespace MonoMac.Foundation
 
 		[Export ("pointValue")]
 		System.Drawing.PointF PointFValue { get; }
+
+		[Export ("rangeValue")]
+		NSRange RangeValue { get; }
 #else
 		[Static, Export ("valueWithCMTime:"), Since (4,0)]
 		NSValue FromCMTime (CMTime time);


### PR DESCRIPTION
To be able to do something like this:

 NSRange bla = ((NSValue)notification.UserInfo.ValueForKey (new NSString ("NSOldSelectedCharacterRange"))).RangeValue;

when I'm notified about a selection change by my NSTextView, I need to get the NSRange from the NSValue. Please include my simple patch to make this work.

Thanks!
