### PR TITLE
Allow setting Link attributes in NSAttributedString.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -122,6 +122,13 @@ namespace MonoMac.Foundation
 		NSString FontAttributeName { get; }
 
 #if MONOMAC
+		[Field ("NSLinkAttributeName", "AppKit")]
+#else
+		[Field ("NSLinkAttributeName")]
+#endif
+		NSString LinkAttributeName { get; }
+
+#if MONOMAC
 		[Field ("NSUnderlineStyleAttributeName", "AppKit")]
 #else
 		[Field ("NSUnderlineStyleAttributeName")]


### PR DESCRIPTION
This change allows me to mark a specific range of an attributed string as a link and provide a callback in the NSTextViewDelegate like this:

``` c#
public override bool LinkClicked (NSTextView textView, NSObject link, uint charIndex)
{
    Console.WriteLine ("LINK CLICKED!1 target: {0} -- position clicked: {1}", link, charIndex);
    return true;
}
```

\o/
