### PR TITLE
rename "filter" selector to actual "filters"

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -491,7 +491,7 @@ namespace MonoMac.CoreAnimation {
 		[Export ("addConstraint:")]
 		void AddConstraint (CAConstraint c);
 
-		[Export ("filter")]
+		[Export ("filters")]
 		CIFilter [] Filters { get; set; }
 #else
 		[Since (3,2)]


### PR DESCRIPTION
fixed a bug with CALayer binding
