### PR TITLE
Add NSAttributedString.CursorAttributeName

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -128,6 +128,9 @@ namespace MonoMac.Foundation
 		[Export("size")]
 		SizeF Size { get; }
 
+		[Field ("NSCursorAttributeName", "AppKit")]
+		NSString CursorAttributeName { get; }
+
 		[Field ("NSFontAttributeName", "AppKit")]
 		NSString FontAttributeName { get; }
 


### PR DESCRIPTION
By adding the _CursorAttributeName_ field to _NSAttributedString_ we gain the possibility to change the mouse pointer shape for specific text regions in _NSTextView_ et al. Who would not want to trick their users like this:

``` c#
// muaha.
myTextView.LinkTextAttributes = NSDictionary.FromObjectAndKey (
  NSCursor.OperationNotAllowedCursor,
  NSAttributedString.CursorAttributeName
);
```
