### PR TITLE
Adding missing NSString methods from NSPathUtilities.h

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2397,8 +2397,6 @@ namespace MonoMac.Foundation
 		
 		[Export("bookmarkDataWithContentsOfURL:error:")]
 		[Static]
-		NSData BookmarkDataWithContentsOfURL( NSUrl bookmarkFileUrl, out NSError error );		
-
 		NSData GetBookmarkData (NSUrl bookmarkFileUrl, out NSError error);
 
 		[Export("URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:")]


### PR DESCRIPTION
These methods are part of Foundation (both on MacOS and iOS), but are declared at **[NSPathUtilities](https://gist.github.com/2974829)**. They were not available on maccore and I need them to do some file name cleanups (that can't be done on System.IO as System.IO doesn't handle symlinks).
