### PR TITLE
[Fix] Do not generate monotouch references in response to MarshalNativeExceptions attribute

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1277,8 +1277,10 @@ public class Generator {
 	{
 		var sb = new StringBuilder ();
 
+#if !MONOMAC
 		if (HasAttribute (mi, typeof (MarshalNativeExceptionsAttribute)))
 			sb.Append ("monotouch_");
+#endif
 		
 		try {
 			sb.Append (ParameterGetMarshalType (mi));


### PR DESCRIPTION
The generator was prepending monotouch_ and adding __Internal DllImport references as if linking against monotouch.a. This patch stops the prefix generation on MonoMac which allows a normal import to be generated.
