### PR TITLE
[Fix] Fixing AOT by changing private delegate in SystemSound to use named delegate instead of Action<>

### DIFF
--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -52,7 +52,8 @@ namespace MonoMac.AudioToolbox {
 
 		Action completionRoutine;
 		GCHandle gc_handle;
-		static readonly Action<SystemSoundId, IntPtr> SoundCompletionCallback = SoundCompletionShared;
+		delegate void _SoundCompletionCallback (SystemSoundId id, IntPtr clientData);
+		static readonly _SoundCompletionCallback SoundCompletionCallback = SoundCompletionShared;
 
 		internal SystemSound (uint soundId, bool ownsHandle)
 		{
@@ -210,9 +211,9 @@ namespace MonoMac.AudioToolbox {
 		}
 
 		[DllImport (Constants.AudioToolboxLibrary)]
-		static extern AudioServicesError AudioServicesAddSystemSoundCompletion (uint soundId, IntPtr runLoop, IntPtr runLoopMode, Action<SystemSoundId, IntPtr> completionRoutine, IntPtr clientData);
+		static extern AudioServicesError AudioServicesAddSystemSoundCompletion (uint soundId, IntPtr runLoop, IntPtr runLoopMode, _SoundCompletionCallback completionRoutine, IntPtr clientData);
 
-		[MonoPInvokeCallback (typeof (Action<SystemSoundId, IntPtr>))]
+		[MonoPInvokeCallback (typeof (_SoundCompletionCallback))]
 		static void SoundCompletionShared (SystemSoundId id, IntPtr clientData)
 		{
 			GCHandle gch = GCHandle.FromIntPtr (clientData);


### PR DESCRIPTION
The AOT compiler will abort with an assert when it encounters an Action<> delegate as a MonoPInvokeCallback because reflection is unable to resolve the type (generics issue most likely). This fix updates SystemSound to use a named delegate instead.
