### PR TITLE
Adding NSUrl methods necessary for handling sandboxed access to the file system in MonoMac

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2376,12 +2376,31 @@ namespace MonoMac.Foundation
 
 		/* These methods come from NURL_AppKitAdditions */
 
-		[Export ("URLFromPasteboard:")][Static]
+		[Export ("URLFromPasteboard:")]
+		[Static]
 		NSUrl FromPasteboard (NSPasteboard pasteboard);
 
 		[Export ("writeToPasteboard:")]
 		void WriteToPasteboard (NSPasteboard pasteboard);
 		
+		[Export("bookmarkDataWithContentsOfURL:error:")]
+		[Static]
+		NSData BookmarkDataWithContentsOfURL( NSUrl bookmarkFileUrl, out NSError error );
+
+		[Export("URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:")]
+		[Static]
+		NSUrl URLByResolvingBookmarkData( NSData data, NSUrlBookmarkResolutionOptions options, [NullAllowed] NSUrl relativeToUrl, bool isStale, out NSError error );
+
+		[Export("writeBookmarkData:toURL:options:error:")]
+		[Static]
+		bool WriteBookmarkDataToUrl( NSData data, NSUrl bookmarkFileUrl, NSUrlBookmarkCreationOptions options, out NSError error );
+
+		[Export("startAccessingSecurityScopedResource")]
+		bool StartAccessingSecurityScopedResource();
+
+		[Export("stopAccessingSecurityScopedResource")]
+		bool StopAccessingSecurityScopedResource();
+
 #endif
 
 		[Export ("getResourceValue:forKey:error:"), Internal]
@@ -2711,10 +2730,10 @@ namespace MonoMac.Foundation
 		NSString IsExcludedFromBackupKey { get; }
 
 		[Export ("bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:")]
-		NSData CreateBookmarkData (NSUrlBookmarkCreationOptions options, string [] resourceValues, NSUrl relativeUrl, out NSError error);
+		NSData CreateBookmarkData (NSUrlBookmarkCreationOptions options, string [] resourceValues, [NullAllowed] NSUrl relativeUrl, out NSError error);
 
 		[Export ("initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:")]
-		IntPtr Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
+		IntPtr Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, [NullAllowed] NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
 
 		[Field ("NSURLPathKey")]
 		[Since (6,0)]


### PR DESCRIPTION
These methods are necessary for MonoMac applications that need to access the external file system when running the application in sandbox mode. They are used to create the security enabled bookmark data and then to evaluate the same security enabled bookmark data to an URL that the application can use inside the sandbox.

Fore more information about these methods check the [NSURL](https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html) class documentation, mainly the **Working with Bookmark Data** and **Security-Scoped URLs and String Paths** sections.
