### PR TITLE
Adding missing NSString methods from NSPathUtilities.h

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3781,6 +3781,53 @@ namespace MonoMac.Foundation
 		[Export ("stringByReplacingCharactersInRange:withString:")]
 		NSString Replace (NSRange range, NSString replacement);
 
+		// start methods from NSStringPathExtensions category
+
+		[Static]
+		[Export("pathWithComponents:")]
+		string[] PathWithComponents( string[] components );
+
+		[Export("pathComponents")]
+		string[] PathComponents { get; }
+
+		[Export("isAbsolutePath")]
+		bool IsAbsolutePath { get; }
+
+		[Export("lastPathComponent")]
+		NSString LastPathComponent { get; }
+
+		[Export("stringByDeletingLastPathComponent")]
+		NSString DeleteLastPathComponent();
+ 
+ 		[Export("stringByAppendingPathComponent:")]
+ 		NSString AppendPathComponent( NSString str );
+
+ 		[Export("pathExtension")]
+ 		NSString PathExtension { get; }
+
+ 		[Export("stringByDeletingPathExtension")]
+ 		NSString DeletePathExtension();
+
+ 		[Export("stringByAppendingPathExtension:")]
+ 		NSString AppendPathExtension( NSString str );
+ 
+ 		[Export("stringByAbbreviatingWithTildeInPath")]
+ 		NSString AbbreviateTildeInPath();
+
+ 		[Export("stringByExpandingTildeInPath")]
+ 		NSString ExpandTildeInpath();
+ 
+ 		[Export("stringByStandardizingPath")]
+ 		NSString StandarizePath();
+
+ 		[Export("stringByResolvingSymlinksInPath")]
+ 		NSString ResolveSymlinksInPath();
+
+ 		[Export("stringsByAppendingPaths")]
+ 		string[] AppendPaths( string[] paths );
+
+		// end methods from NSStringPathExtensions category
+
 		[Since (6,0)]
 		[Export ("capitalizedStringWithLocale:")]
 		string Capitalize (NSLocale locale);


### PR DESCRIPTION
These methods are part of Foundation (both on MacOS and iOS), but are declared at **[NSPathUtilities](https://gist.github.com/2974829)**. They were not available on maccore and I need them to do some file name cleanups (that can't be done on System.IO as System.IO doesn't handle symlinks).

This is a re-doing of https://github.com/mono/maccore/pull/30 from a clean branch.
