### PR TITLE
Adding methods to turn a common NSUrl to a file based NSUrl and adding AppStoreReceiptUrl to NSBundle

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2586,6 +2586,12 @@ namespace MonoMac.Foundation
 
 		[Export("stopAccessingSecurityScopedResource")]
 		void StopAccessingSecurityScopedResource();
+	
+		[Export("filePathURL")]
+		NSUrl FilePathUrl { get; }
+
+		[Export("fileReferenceURL")]
+		NSUrl FileReferenceUrl { get; }		
 
 #endif
 
@@ -4367,6 +4373,10 @@ namespace MonoMac.Foundation
 
 		[Export ("pathForSoundResource:")]
 		string PathForSoundResource (string resource);
+
+		[Export("appStoreReceiptURL")]
+		NSUrl AppStoreReceiptUrl { get; }
+
 #else
 		// http://developer.apple.com/library/ios/#documentation/uikit/reference/NSBundle_UIKitAdditions/Introduction/Introduction.html
 		[Export ("loadNibNamed:owner:options:")]


### PR DESCRIPTION
The `AppStoreReceiptUrl` is the right way to access the in app purchases receipt for an application running in the sandbox in OSX (since the `transactionReceipt` is always `nil` for `SKTransactionPayment` objects in OSX).

The `NSURL` methods were missing from the current bindings, they are used to turn common `NSURL` objects into file based `NSURL` objects.
