### PR TITLE
Add missing valueWithRange method to NSValue

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4946,6 +4946,9 @@ namespace MonoMac.Foundation
 	
 		[Export ("isEqualToValue:")]
 		bool IsEqualTo (NSValue value);
+		
+		[Export ("valueWithRange:")][Static]
+		NSValue FromRange(NSRange range);
 	
 #if MONOMAC
 		[Static, Export ("valueWithCMTime:"), Lion]


### PR DESCRIPTION
Method available on both [OS X](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSValue_Class/Reference/Reference.html#//apple_ref/occ/clm/NSValue/valueWithRange:) and [iOS](http://developer.apple.com/library/ios/#documentation/cocoa/reference/foundation/Classes/NSValue_Class/Reference/Reference.html#//apple_ref/occ/clm/NSValue/valueWithRange:)
