### PR TITLE
CTFontGetGlyphsForCharacters takes UniChar instead of single byte chars.

### DIFF
--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1878,7 +1878,7 @@ namespace MonoMac.CoreText {
 			return languages;
 		}
 
-		[DllImport (Constants.CoreTextLibrary)]
+		[DllImport (Constants.CoreTextLibrary, CharSet = CharSet.Unicode)]
 		static extern bool CTFontGetGlyphsForCharacters (IntPtr font, [In] char[] characters, [Out] CGGlyph[] glyphs, int count);
 		public bool GetGlyphsForCharacters (char[] characters, CGGlyph[] glyphs, int count)
 		{


### PR DESCRIPTION
This change fixes the truncation of non-8bit character codes.
