### PR TITLE
Add [NullAllowed] to afterItem on AVQueuePlayer's CanInsert/InsertItem

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -4292,10 +4292,10 @@ namespace MonoMac.AVFoundation {
 		void AdvanceToNextItem ();
 
 		[Export ("canInsertItem:afterItem:")]
-		bool CanInsert (AVPlayerItem item, AVPlayerItem afterItem);
+		bool CanInsert (AVPlayerItem item, [NullAllowed] AVPlayerItem afterItem);
 
 		[Export ("insertItem:afterItem:")]
-		void InsertItem (AVPlayerItem item, AVPlayerItem afterItem);
+		void InsertItem (AVPlayerItem item, [NullAllowed] AVPlayerItem afterItem);
 
 		[Export ("removeItem:")]
 		void RemoveItem (AVPlayerItem item);


### PR DESCRIPTION
Apple's documentation [1] indicates nil is allowed for afterItem on AVQueuePlayer's canInsertItem:afterItem: and insertItem:afterItem:.

[1] https://developer.apple.com/library/ios/#documentation/AVFoundation/Reference/AVQueuePlayer_Class/Reference/Reference.html
