### PR TITLE
Fix generator so that OverrideAttribute is a known attribute for methods

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1663,6 +1663,8 @@ public class Generator {
 						continue;
 					} else if (attr is SealedAttribute || attr is EventArgsAttribute || attr is DelegateNameAttribute || attr is EventNameAttribute || attr is ObsoleteAttribute || attr is AlphaAttribute || attr is NewAttribute || attr is SinceAttribute || attr is PostGetAttribute || attr is NullAllowedAttribute || attr is CheckDisposedAttribute || attr is SnippetAttribute || attr is LionAttribute || attr is MountainLionAttribute || attr is AppearanceAttribute || attr is ThreadSafeAttribute || attr is AutoreleaseAttribute || attr is EditorBrowsableAttribute || attr is AdviceAttribute)
 						continue;
+					else if (attr is OverrideAttribute)
+						continue;
 					else if (attr is MarshalNativeExceptionsAttribute)
 						continue;
 					else if (attr is WrapAttribute)


### PR DESCRIPTION
Adding the OverrideAttribute to a method throws "Unknown attribute" BindingException without this fix.
