### PR TITLE
Refactor CoreFoundation objects so that they derive from a common base class

### DIFF
--- a/src/AddressBook/ABMultiValue.cs
+++ b/src/AddressBook/ABMultiValue.cs
@@ -162,9 +162,8 @@ namespace MonoMac.AddressBook {
 		}
 	}
 
-	public class ABMultiValue<T> : INativeObject, IDisposable, IEnumerable<ABMultiValueEntry<T>>
+	public class ABMultiValue<T> : CFType, IEnumerable<ABMultiValueEntry<T>>
 	{
-		IntPtr handle;
 		internal Converter<IntPtr, T> toManaged;
 		internal Converter<T, IntPtr> toNative;
 
@@ -186,7 +185,7 @@ namespace MonoMac.AddressBook {
 			if (toNative == null)
 				throw new ArgumentNullException ("toNative");
 
-			this.handle = handle;
+			Handle = handle;
 			this.toManaged = toManaged;
 			this.toNative  = toNative;
 		}
@@ -196,35 +195,9 @@ namespace MonoMac.AddressBook {
 			Dispose (false);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero)
-				CFObject.CFRelease (handle);
-			handle = IntPtr.Zero;
-		}
-
-		internal void AssertValid ()
-		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("");
-		}
-
-		public IntPtr Handle {
-			get {
-				AssertValid ();
-				return handle;
-			}
-		}
-
 		public virtual bool IsReadOnly {
 			get {
-				AssertValid ();
+				ThrowIfDisposed ();
 				return true;
 			}
 		}
@@ -295,7 +268,7 @@ namespace MonoMac.AddressBook {
 
 		public override bool IsReadOnly {
 			get {
-				AssertValid ();
+				ThrowIfDisposed ();
 				return false;
 			}
 		}

--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -55,18 +55,13 @@ namespace MonoMac.AddressBook {
 		MultiDictionary = ABMultiValue.Mask | Dictionary,
 	}
 
-	public abstract class ABRecord : INativeObject, IDisposable {
+	public abstract class ABRecord : CFType {
 
 		public const int InvalidRecordId = -1;
 		public const int InvalidPropertyId = -1;
 
-		IntPtr handle;
-
-		internal ABRecord (IntPtr handle, bool owns)
+		internal ABRecord (IntPtr handle, bool owns) : base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
 		}
 
 		internal static ABRecord FromHandle (IntPtr handle, ABAddressBook addressbook, bool owns = true)
@@ -101,24 +96,10 @@ namespace MonoMac.AddressBook {
 			Dispose (false);
 		}
 
-		public void Dispose ()
+		protected override void Dispose (bool disposing)
 		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero)
-				CFObject.CFRelease (handle);
-			handle = IntPtr.Zero;
+			base.Dispose (disposing);
 			AddressBook = null;
-		}
-
-		void AssertValid ()
-		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("");
 		}
 
 		internal ABAddressBook AddressBook {
@@ -127,11 +108,11 @@ namespace MonoMac.AddressBook {
 
 		public IntPtr Handle {
 			get {
-				AssertValid ();
-				return handle;
+				ThrowIfDisposed ();
+				return Handle;
 			}
 			internal set {
-				handle = value;				
+				Handle = value;
 			}
 		}
 

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -293,7 +293,7 @@ namespace MonoMac.AudioToolbox {
 				return;
 
 			for (int i = 0; i < Count; ++i) {
-				CFObject.CFRelease (this [i].Name_cfstringref);
+				CFType.Release (this [i].Name_cfstringref);
 			}
 
 			Marshal.FreeHGlobal (ptr);
@@ -453,7 +453,7 @@ namespace MonoMac.AudioToolbox {
 				return;
 
 			for (int i = 0; i < Count; ++i) {
-				CFObject.CFRelease (this [i].NameWeak);
+				CFType.Release (this [i].NameWeak);
 			}
 
 			Marshal.FreeHGlobal (ptr);

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -98,12 +98,12 @@ namespace MonoMac.CoreAnimation {
 		public object WeakFont {
 			get {
 				var handle = _Font;
-				int type = CFType.GetTypeID (handle);
-				if (type == CTFont.GetTypeID ())
+				var type = CFType.GetTypeID (handle);
+				if (type == CTFont.TypeID)
 					return new CTFont (handle);
-				else if (type == CGFont.GetTypeID ())
+				else if (type == CGFont.TypeID)
 					return new CGFont (handle, false);
-				else if (type == CFString.GetTypeID ())
+				else if (type == CFString.TypeID)
 					return CFString.FetchString (handle);
 #if MONOMAC
 				else return (NSFont) Runtime.GetNSObject (handle);

--- a/src/CoreFoundation/CFAllocator.cs
+++ b/src/CoreFoundation/CFAllocator.cs
@@ -33,7 +33,7 @@ using MonoMac.Foundation;
 using MonoMac.ObjCRuntime;
 
 namespace MonoMac.CoreFoundation {	
-	public class CFAllocator : INativeObject, IDisposable 
+	public class CFAllocator : CFType
 	{
 		static CFAllocator Default_cf;
 		static CFAllocator SystemDefault_cf;
@@ -48,8 +48,6 @@ namespace MonoMac.CoreFoundation {
 		internal static readonly IntPtr null_ptr;
 		//static readonly IntPtr UseContextFlag;
 
-		IntPtr handle;
-		
 		static CFAllocator ()
 		{
 			var handle = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
@@ -66,38 +64,18 @@ namespace MonoMac.CoreFoundation {
 		}
 
 		public CFAllocator (IntPtr handle)
+			: this (handle, false)
 		{
-			this.handle = handle;
 		}
 
 		public CFAllocator (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
 		}
 
 		~CFAllocator ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		public static CFAllocator Default {
@@ -135,7 +113,7 @@ namespace MonoMac.CoreFoundation {
 
 		public IntPtr Allocate (long size, CFAllocatorFlags hint = 0)
 		{
-			return CFAllocatorAllocate (handle, size, hint);
+			return CFAllocatorAllocate (Handle, size, hint);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -143,7 +121,7 @@ namespace MonoMac.CoreFoundation {
 
 		public void Deallocate (IntPtr ptr)
 		{
-			CFAllocatorDeallocate (handle, ptr);
+			CFAllocatorDeallocate (Handle, ptr);
 		}
 
 		// TODO: Implement more methods

--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -38,9 +38,7 @@ using CFIndex = System.Int32;
 
 namespace MonoMac.CoreFoundation {
 	
-	class CFArray : INativeObject, IDisposable {
-
-		internal IntPtr handle;
+	class CFArray : CFType {
 
 		internal CFArray (IntPtr handle)
 			: this (handle, false)
@@ -49,39 +47,20 @@ namespace MonoMac.CoreFoundation {
 
 		[Preserve (Conditional = true)]
 		internal CFArray (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFArrayGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFArrayGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFArrayGetTypeID (); }
+		}
 
 		~CFArray ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		// pointer to a const struct (REALLY APPLE?)
@@ -111,7 +90,7 @@ namespace MonoMac.CoreFoundation {
 		}
 
 		public int Count {
-			get {return CFArrayGetCount (handle);}
+			get {return CFArrayGetCount (Handle);}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -122,7 +101,7 @@ namespace MonoMac.CoreFoundation {
 
 		public IntPtr GetValue (int index)
 		{
-			return CFArrayGetValueAtIndex (handle, new IntPtr (index));
+			return CFArrayGetValueAtIndex (Handle, new IntPtr (index));
 		}
 
 		public static unsafe IntPtr Create (params IntPtr[] values)

--- a/src/CoreFoundation/CFBoolean.cs
+++ b/src/CoreFoundation/CFBoolean.cs
@@ -38,9 +38,7 @@ using MonoMac.Foundation;
 
 namespace MonoMac.CoreFoundation {
 	[Since (3,2)]
-	class CFBoolean : INativeObject, IDisposable {
-		IntPtr handle;
-
+	class CFBoolean : CFType {
 		public static readonly CFBoolean True;
 		public static readonly CFBoolean False;
 
@@ -60,10 +58,8 @@ namespace MonoMac.CoreFoundation {
 
 		[Preserve (Conditional = true)]
 		internal CFBoolean (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		~CFBoolean ()
@@ -71,27 +67,11 @@ namespace MonoMac.CoreFoundation {
 			Dispose (false);
 		}
 
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
-		}
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFBooleanGetTypeID ();
 
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFBooleanGetTypeID")]
-		public extern static int GetTypeID ();
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
+		public static uint TypeID {
+			get { return CFBooleanGetTypeID (); }
 		}
 
 		public static implicit operator bool (CFBoolean value)
@@ -113,7 +93,7 @@ namespace MonoMac.CoreFoundation {
 		extern static bool CFBooleanGetValue (IntPtr boolean);
 
 		public bool Value {
-			get {return CFBooleanGetValue (handle);}
+			get {return CFBooleanGetValue (Handle);}
 		}
 
 		public static bool GetValue (IntPtr boolean)

--- a/src/CoreFoundation/CFData.cs
+++ b/src/CoreFoundation/CFData.cs
@@ -33,47 +33,29 @@ using MonoMac.ObjCRuntime;
 
 namespace MonoMac.CoreFoundation {
 
-	class CFData : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	class CFData : CFType {
 		public CFData (IntPtr handle)
 			: this (handle, false)
 		{
 		}
 
 		public CFData (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
 		}
 
 		~CFData ()
 		{
 			Dispose (false);
 		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFDataGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFDataGetTypeID (); }
 		}
 
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFDataGetTypeID")]
-		public extern static int GetTypeID ();
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-		
 		public static CFData FromDataNoCopy (IntPtr buffer, int length)
 		{
 			return new CFData (CFDataCreateWithBytesNoCopy (IntPtr.Zero, buffer, length, CFAllocator.null_ptr), true);
@@ -83,7 +65,7 @@ namespace MonoMac.CoreFoundation {
 		extern static IntPtr CFDataCreateWithBytesNoCopy (IntPtr allocator, IntPtr bytes, int len, IntPtr deallocator);
 
 		public int Length {
-			get { return CFDataGetLength (handle); }
+			get { return CFDataGetLength (Handle); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -92,7 +74,7 @@ namespace MonoMac.CoreFoundation {
 		public byte[] GetBuffer ()
 		{
 			var buffer = new byte [Length];
-			var ptr = CFDataGetBytePtr (handle);
+			var ptr = CFDataGetBytePtr (Handle);
 			Marshal.Copy (ptr, buffer, 0, buffer.Length);
 			return buffer;
 		}
@@ -104,7 +86,7 @@ namespace MonoMac.CoreFoundation {
 		 * Exposes a read-only pointer to the underlying storage.
 		 */
 		public IntPtr Bytes {
-			get { return CFDataGetBytePtr (handle); }
+			get { return CFDataGetBytePtr (Handle); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -36,9 +36,7 @@ using MonoMac.ObjCRuntime;
 namespace MonoMac.CoreFoundation {
 
 	[Since (3,2)]
-	class CFDictionary : INativeObject, IDisposable {
-		public IntPtr Handle { get; private set; }
-	
+	class CFDictionary : CFType {
 		public static IntPtr KeyCallbacks;
 		public static IntPtr ValueCallbacks;
 
@@ -48,32 +46,20 @@ namespace MonoMac.CoreFoundation {
 		}
 
 		public CFDictionary (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.Handle = handle;
 		}
-		
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFDictionaryGetTypeID")]
-		public extern static int GetTypeID ();
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFDictionaryGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFDictionaryGetTypeID (); }
+		}
 
 		~CFDictionary ()
 		{
 			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
 		}
 
 		static CFDictionary ()
@@ -152,7 +138,7 @@ namespace MonoMac.CoreFoundation {
 		public string GetStringValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionaryGetValue (Handle, str.handle));
+				return CFString.FetchString (CFDictionaryGetValue (Handle, str.Handle));
 			}
 		}
 
@@ -179,14 +165,14 @@ namespace MonoMac.CoreFoundation {
 		public IntPtr GetIntPtrValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFDictionaryGetValue (Handle, str.handle);
+				return CFDictionaryGetValue (Handle, str.Handle);
 			}
 		}
 
 		public CFDictionary GetDictionaryValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				var ptr = CFDictionaryGetValue (Handle, str.handle);
+				var ptr = CFDictionaryGetValue (Handle, str.Handle);
 				return ptr == IntPtr.Zero ? null : new CFDictionary (ptr);
 			}
 		}
@@ -194,7 +180,7 @@ namespace MonoMac.CoreFoundation {
 		public bool ContainsKey (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFDictionaryContainsKey (Handle, str.handle);
+				return CFDictionaryContainsKey (Handle, str.Handle);
 			}
 		}
 

--- a/src/CoreFoundation/CFException.cs
+++ b/src/CoreFoundation/CFException.cs
@@ -119,7 +119,7 @@ namespace MonoMac.CoreFoundation {
 				}
 			}
 			if (release)
-				CFObject.CFRelease (cfErrorHandle);
+				CFType.Release (cfErrorHandle);
 			return e;
 		}
 
@@ -137,7 +137,7 @@ namespace MonoMac.CoreFoundation {
 		{
 			var r = CFString.FetchString (cfStringRef);
 			if (release && (cfStringRef != IntPtr.Zero))
-				CFObject.CFRelease (cfStringRef);
+				CFType.Release (cfStringRef);
 			return r;
 		}
 

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -123,7 +123,7 @@ namespace MonoMac.CoreFoundation {
 
 		public int Read (byte[] buffer, int offset, int count)
 		{
-			CheckHandle ();
+			ThrowIfDisposed ();
 			if (offset < 0)
 				throw new ArgumentException ();
 			if (count < 1)

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -78,19 +78,10 @@ namespace MonoMac.CoreFoundation {
 		}
 	}
 
-	public static class CFObject {
-		[DllImport (Constants.CoreFoundationLibrary)]
-		internal extern static void CFRelease (IntPtr obj);
-
-		[DllImport (Constants.CoreFoundationLibrary)]
-		internal extern static IntPtr CFRetain (IntPtr obj);
-	}
-	
-	public class CFString : INativeObject, IDisposable {
-		internal IntPtr handle;
+	public class CFString : CFType
+	{
 		internal string str;
-		
-		
+
 		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
 		extern static IntPtr CFStringCreateWithCharacters (IntPtr allocator, string str, int count);
 
@@ -108,7 +99,7 @@ namespace MonoMac.CoreFoundation {
 			if (str == null)
 				throw new ArgumentNullException ("str");
 			
-			handle = CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
+			Handle = CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
 			this.str = str;
 		}
 
@@ -117,41 +108,28 @@ namespace MonoMac.CoreFoundation {
 			Dispose (false);
 		}
 
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
+		[DllImport (Constants.CoreTextLibrary)]
+		extern static uint CFStringGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFStringGetTypeID (); }
 		}
 
-		[DllImport (Constants.CoreTextLibrary, EntryPoint="CFStringGetTypeID")]
-		public extern static int GetTypeID ();
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public virtual void Dispose (bool disposing)
+		protected override void Dispose (bool disposing)
 		{
 			str = null;
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			base.Dispose (disposing);
 		}
-		
+
 		public CFString (IntPtr handle)
 			: this (handle, false)
 		{
 		}
-		
+
 		[Preserve (Conditional = true)]
 		internal CFString (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		internal static string FetchString (IntPtr handle)
@@ -183,7 +161,7 @@ namespace MonoMac.CoreFoundation {
 		public static implicit operator string (CFString x)
 		{
 			if (x.str == null)
-				x.str = FetchString (x.handle);
+				x.str = FetchString (x.Handle);
 			
 			return x.str;
 		}
@@ -198,7 +176,7 @@ namespace MonoMac.CoreFoundation {
 				if (str != null)
 					return str.Length;
 				else
-					return CFStringGetLength (handle);
+					return CFStringGetLength (Handle);
 			}
 		}
 
@@ -210,7 +188,7 @@ namespace MonoMac.CoreFoundation {
 				if (str != null)
 					return str [p];
 				else
-					return CFStringGetCharacterAtIndex (handle, p);
+					return CFStringGetCharacterAtIndex (Handle, p);
 			}
 		}
 		
@@ -218,7 +196,7 @@ namespace MonoMac.CoreFoundation {
 		{
 			if (str != null)
 				return str;
-			return FetchString (handle);
+			return FetchString (Handle);
 		}
 	}
 }

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -3,27 +3,75 @@
 //
 using System;
 using System.Runtime.InteropServices;
+using MonoMac.Foundation;
 using MonoMac.ObjCRuntime;
 
 namespace MonoMac.CoreFoundation {
-	public class CFType {
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFGetTypeID")]
-		public static extern int GetTypeID (IntPtr typeRef);
+	public abstract class CFType : INativeObject, IDisposable
+	{
+		protected CFType ()
+		{
+		}
+
+		[Preserve (Conditional = true)]
+		internal CFType (IntPtr handle, bool owns)
+		{
+			if (handle == IntPtr.Zero)
+				throw new ArgumentNullException ("handle");
+			if (!owns)
+				Retain (handle);
+			Handle = handle;
+		}
+
+		public IntPtr Handle { get; internal set; }
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFGetTypeID (IntPtr typeRef);
+
+		public static uint GetTypeID (IntPtr handle) {
+			return CFGetTypeID (handle);
+		}
+
+		public uint GetTypeID () {
+			return CFGetTypeID (Handle);
+		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFCopyDescription (IntPtr ptr);
 
-		public string GetDescription (IntPtr handle)
-		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
-			
-			using (var s = new CFString (CFCopyDescription (handle)))
-				return s.ToString ();
-		}
-		
-	}
 
-	public interface ICFType : INativeObject {
+		public string Description {
+			get {
+				ThrowIfDisposed ();
+				using (var s = new CFString (CFCopyDescription (Handle)))
+					return s.ToString ();
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (Handle != IntPtr.Zero){
+				Release (Handle);
+				Handle = IntPtr.Zero;
+			}
+		}
+
+		protected void ThrowIfDisposed ()
+		{
+			if (Handle == IntPtr.Zero)
+				throw new ObjectDisposedException (GetType ().Name);
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary, EntryPoint = "CFRelease")]
+		internal extern static void Release (IntPtr obj);
+
+		[DllImport (Constants.CoreFoundationLibrary, EntryPoint = "CFRetain")]
+		internal extern static IntPtr Retain (IntPtr obj);
 	}
 }

--- a/src/CoreFoundation/CFUrl.cs
+++ b/src/CoreFoundation/CFUrl.cs
@@ -39,41 +39,21 @@ namespace MonoMac.CoreFoundation {
 		HFS = 1,
 		Windows = 2
 	};
-	
-	public class CFUrl : INativeObject, IDisposable {
-		internal IntPtr handle;
 
+	public class CFUrl : CFType {
 		~CFUrl ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
 		extern static IntPtr CFURLCreateWithFileSystemPath (IntPtr allocator, IntPtr cfstringref, CFUrlPathStyle pathstyle, bool isdir);
 		
 		internal CFUrl (IntPtr handle)
+			: base (handle, true)
 		{
-			this.handle = handle;
 		}
-		
+
 		static public CFUrl FromFile (string filename)
 		{
 			using (var str = new CFString (filename)){
@@ -107,7 +87,7 @@ namespace MonoMac.CoreFoundation {
 		
 		public override string ToString ()
 		{
-			using (var str = new CFString (CFURLGetString (handle))) {
+			using (var str = new CFString (CFURLGetString (Handle))) {
 				return str.ToString ();
 			}
 		}
@@ -117,7 +97,7 @@ namespace MonoMac.CoreFoundation {
 		
 		public string FileSystemPath {
 			get {
-				return GetFileSystemPath (handle);
+				return GetFileSystemPath (Handle);
 			}
 		}
 
@@ -127,8 +107,12 @@ namespace MonoMac.CoreFoundation {
 				return str.ToString ();
 		}
 
-		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFURLGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static uint CFURLGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFURLGetTypeID (); }
+		}
 	}
 	
 }

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -93,7 +93,7 @@ namespace MonoMac.CoreFoundation {
 
 		public int Write (byte[] buffer, int offset, int count)
 		{
-			CheckHandle ();
+			ThrowIfDisposed ();
 			if (offset < 0)
 				throw new ArgumentException ();
 			if (count < 1)

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -111,7 +111,7 @@ namespace MonoMac.CoreGraphics {
 				throw new ArgumentNullException ("name");
 			
 			using (var s = new CFString (name)){
-				handle = CGColorGetConstantColor (s.handle);
+				handle = CGColorGetConstantColor (s.Handle);
 				if (handle == IntPtr.Zero)
 					throw new ArgumentException ("name");
 			}

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -824,7 +824,7 @@ namespace MonoMac.CoreGraphics {
 		extern static void CGContextSetFont(IntPtr c, IntPtr font);
 		public void SetFont (CGFont font)
 		{
-			CGContextSetFont (handle, font.handle);
+			CGContextSetFont (handle, font.Handle);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -97,7 +97,7 @@ namespace MonoMac.CoreGraphics {
 		public static CGFont CreateWithFontName (string name)
 		{
 			using (CFString s = name){
-				return new CGFont (CGFontCreateWithFontName (s.handle), true);
+				return new CGFont (CGFontCreateWithFontName (s.Handle), true);
 			}
 		}
 		
@@ -222,7 +222,7 @@ namespace MonoMac.CoreGraphics {
 		public ushort GetGlyphWithGlyphName (string s)
 		{
 			using (var cs = new CFString (s)){
-				return CGFontGetGlyphWithGlyphName (handle, cs.handle);
+				return CGFontGetGlyphWithGlyphName (handle, cs.Handle);
 			}
 		}
 		
@@ -272,7 +272,11 @@ namespace MonoMac.CoreGraphics {
 		ToCTFont() overloads where attributes is CTFontDescriptorRef
 #endif // TODO
 
-		[DllImport (Constants.CoreTextLibrary, EntryPoint="CGFontGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.CoreTextLibrary)]
+		extern static uint CGFontGetTypeID ();
+
+		public static uint TypeID {
+			get { return CGFontGetTypeID (); }
+		}
 	}
 }

--- a/src/CoreGraphics/CGPDFStream.cs
+++ b/src/CoreGraphics/CGPDFStream.cs
@@ -62,7 +62,7 @@ namespace MonoMac.CoreGraphics {
 				int format;
 				IntPtr obj = CGPDFStreamCopyData (handle, out format);
 				var ret = new NSData (obj);
-				CFObject.CFRelease (obj);
+				CFType.Release (obj);
 				return ret;
 			}
 		}

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -38,44 +38,19 @@ namespace MonoMac.CoreMedia {
 	}
 
 	[Since (4,0)]
-	public class CMBlockBuffer : INativeObject, IDisposable {
-		internal IntPtr handle;
-
-		internal CMBlockBuffer (IntPtr handle)
+	public class CMBlockBuffer : CFType {
+		internal CMBlockBuffer (IntPtr handle) : this (handle, true)
 		{
-			this.handle = handle;
 		}
 
 		[Preserve (Conditional=true)]
-		internal CMBlockBuffer (IntPtr handle, bool owns)
+		internal CMBlockBuffer (IntPtr handle, bool owns) : base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-
-			this.handle = handle;
 		}
 		
 		~CMBlockBuffer ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -96,7 +71,7 @@ namespace MonoMac.CoreMedia {
 		
 		public CMBlockBufferError CopyDataBytes (uint offsetToData, uint dataLength, IntPtr destination)
 		{
-			return CMBlockBufferCopyDataBytes (handle, offsetToData, dataLength, destination);
+			return CMBlockBufferCopyDataBytes (Handle, offsetToData, dataLength, destination);
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -106,7 +81,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMBlockBufferGetDataLength (handle);
+				return CMBlockBufferGetDataLength (Handle);
 			}
 		}
 	}

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -29,46 +29,23 @@ namespace MonoMac.CoreMedia {
 	}
 
 	[Since (4,0)]
-	public class CMFormatDescription : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CMFormatDescription : CFType {
 		internal CMFormatDescription (IntPtr handle)
+			: this (handle, true)
 		{
-			this.handle = handle;
 		}
 
 		[Preserve (Conditional=true)]
 		internal CMFormatDescription (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-
-			this.handle = handle;
 		}
 		
 		~CMFormatDescription ()
 		{
 			Dispose (false);
 		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-		
+				
 		/*[DllImport(Constants.CoreMediaLibrary)]
 		extern static CFPropertyListRef CMFormatDescriptionGetExtension (
 		   CMFormatDescriptionRef desc,
@@ -82,7 +59,7 @@ namespace MonoMac.CoreMedia {
 		
 		public NSDictionary GetExtensions ()
 		{
-			var cfDictRef = CMFormatDescriptionGetExtensions (handle);
+			var cfDictRef = CMFormatDescriptionGetExtensions (Handle);
 			if (cfDictRef == IntPtr.Zero)
 			{
 				return null;
@@ -102,7 +79,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMFormatDescriptionGetMediaSubType (handle);
+				return CMFormatDescriptionGetMediaSubType (Handle);
 			}
 		}
 
@@ -155,16 +132,15 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMFormatDescriptionGetMediaType (handle);
+				return CMFormatDescriptionGetMediaType (Handle);
 			}
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
-		extern static int CMFormatDescriptionGetTypeID ();
+		extern static uint CMFormatDescriptionGetTypeID ();
 		
-		public static int GetTypeID ()
-		{
-			return CMFormatDescriptionGetTypeID ();
+		public static uint TypeID {
+			get { return CMFormatDescriptionGetTypeID (); }
 		}
 
 #if !COREBUILD
@@ -204,7 +180,7 @@ namespace MonoMac.CoreMedia {
 
 		public AudioStreamBasicDescription? AudioStreamBasicDescription {
 			get {
-				var ret = CMAudioFormatDescriptionGetStreamBasicDescription (handle);
+				var ret = CMAudioFormatDescriptionGetStreamBasicDescription (Handle);
 				if (ret != IntPtr.Zero){
 					unsafe {
 						return *((AudioStreamBasicDescription *) ret);
@@ -220,7 +196,7 @@ namespace MonoMac.CoreMedia {
 		public AudioChannelLayout AudioChannelLayout {
 			get {
 				int size;
-				var res = CMAudioFormatDescriptionGetChannelLayout (handle, out size);
+				var res = CMAudioFormatDescriptionGetChannelLayout (Handle, out size);
 				if (res == IntPtr.Zero || size == 0)
 					return null;
 				return AudioChannelLayout.FromHandle (res);
@@ -233,7 +209,7 @@ namespace MonoMac.CoreMedia {
 			get {
 				unsafe {
 					int size;
-					var v = CMAudioFormatDescriptionGetFormatList (handle, out size);
+					var v = CMAudioFormatDescriptionGetFormatList (Handle, out size);
 					if (v == IntPtr.Zero)
 						return null;
 					var items = size / sizeof (AudioFormat);
@@ -252,7 +228,7 @@ namespace MonoMac.CoreMedia {
 		public byte [] AudioMagicCookie {
 			get {
 				int size;
-				var h = CMAudioFormatDescriptionGetMagicCookie (handle, out size);
+				var h = CMAudioFormatDescriptionGetMagicCookie (Handle, out size);
 				if (h == IntPtr.Zero)
 					return null;
 
@@ -269,7 +245,7 @@ namespace MonoMac.CoreMedia {
 		public AudioFormat AudioMostCompatibleFormat {
 			get {
 				unsafe {
-					var ret = (AudioFormat *) CMAudioFormatDescriptionGetMostCompatibleFormat (handle);
+					var ret = (AudioFormat *) CMAudioFormatDescriptionGetMostCompatibleFormat (Handle);
 					if (ret == null)
 						return new AudioFormat ();
 					return *ret;
@@ -283,7 +259,7 @@ namespace MonoMac.CoreMedia {
 		public AudioFormat AudioRichestDecodableFormat {
 			get {
 				unsafe {
-					var ret = (AudioFormat *) CMAudioFormatDescriptionGetRichestDecodableFormat (handle);
+					var ret = (AudioFormat *) CMAudioFormatDescriptionGetRichestDecodableFormat (Handle);
 					if (ret == null)
 						return new AudioFormat ();
 					return *ret;
@@ -297,7 +273,7 @@ namespace MonoMac.CoreMedia {
 		[Advice ("Use CMVideoFormatDescription")]
 		public Size  VideoDimensions {
 			get {
-				return CMVideoFormatDescriptionGetDimensions (handle);
+				return CMVideoFormatDescriptionGetDimensions (Handle);
 			}
 		}
 
@@ -307,7 +283,7 @@ namespace MonoMac.CoreMedia {
 		[Advice ("Use CMVideoFormatDescription")]
 		public RectangleF GetVideoCleanAperture (bool originIsAtTopLeft)
 		{
-			return CMVideoFormatDescriptionGetCleanAperture (handle, originIsAtTopLeft);
+			return CMVideoFormatDescriptionGetCleanAperture (Handle, originIsAtTopLeft);
 		}
 
 		[DllImport (Constants.CoreMediaLibrary)]
@@ -326,7 +302,7 @@ namespace MonoMac.CoreMedia {
 		[Advice ("Use CMVideoFormatDescription")]
 		public SizeF GetVideoPresentationDimensions (bool usePixelAspectRatio, bool useCleanAperture)
 		{
-			return CMVideoFormatDescriptionGetPresentationDimensions (handle, usePixelAspectRatio, useCleanAperture);
+			return CMVideoFormatDescriptionGetPresentationDimensions (Handle, usePixelAspectRatio, useCleanAperture);
 		}
 
 		[DllImport (Constants.CoreMediaLibrary)]
@@ -337,7 +313,7 @@ namespace MonoMac.CoreMedia {
 		{
 			if (imageBuffer == null)
 				throw new ArgumentNullException ("imageBuffer");
-			return CMVideoFormatDescriptionMatchesImageBuffer (handle, imageBuffer.Handle) != 0;
+			return CMVideoFormatDescriptionMatchesImageBuffer (Handle, imageBuffer.Handle) != 0;
 		}
 #endif
 	}
@@ -381,15 +357,17 @@ namespace MonoMac.CoreMedia {
 		public CMVideoFormatDescription (CMVideoCodecType codecType, Size size)
 			: base (IntPtr.Zero)
 		{
+			IntPtr handle;
 			var error = CMVideoFormatDescriptionCreate (IntPtr.Zero, codecType, size.Width, size.Height, IntPtr.Zero, out handle);
 			if (error != CMFormatDescriptionError.None)
 				throw new ArgumentException (error.ToString ());
+			Handle = handle;
 		}
 
 #if !COREBUILD
 		public Size Dimensions {
 			get {
-				return CMVideoFormatDescriptionGetDimensions (handle);
+				return CMVideoFormatDescriptionGetDimensions (Handle);
 			}
 		}
 
@@ -416,12 +394,12 @@ namespace MonoMac.CoreMedia {
 
 		public RectangleF GetCleanAperture (bool originIsAtTopLeft)
 		{
-			return CMVideoFormatDescriptionGetCleanAperture (handle, originIsAtTopLeft);
+			return CMVideoFormatDescriptionGetCleanAperture (Handle, originIsAtTopLeft);
 		}
 
 		public SizeF GetPresentationDimensions (bool usePixelAspectRatio, bool useCleanAperture)
 		{
-			return CMVideoFormatDescriptionGetPresentationDimensions (handle, usePixelAspectRatio, useCleanAperture);
+			return CMVideoFormatDescriptionGetPresentationDimensions (Handle, usePixelAspectRatio, useCleanAperture);
 		}
 #endif
 	}

--- a/src/CoreMedia/CMMemoryPool.cs
+++ b/src/CoreMedia/CMMemoryPool.cs
@@ -17,10 +17,8 @@ using MonoMac.ObjCRuntime;
 namespace MonoMac.CoreMedia {
 
 	[Since (6,0)]
-	public class CMMemoryPool : IDisposable, INativeObject
+	public class CMMemoryPool : CFType
 	{
-		IntPtr handle;
-
 		static readonly IntPtr AgeOutPeriodSelector;
 		
 		static CMMemoryPool ()
@@ -38,7 +36,7 @@ namespace MonoMac.CoreMedia {
 
 		public CMMemoryPool ()
 		{
-			handle = CMMemoryPoolCreate (IntPtr.Zero);
+			Handle = CMMemoryPoolCreate (IntPtr.Zero);
 		}
 
 #if !COREBUILD
@@ -46,7 +44,7 @@ namespace MonoMac.CoreMedia {
 		{
 			using (var dict = new NSMutableDictionary ()) {
 				dict.LowlevelSetObject (AgeOutPeriodSelector, new NSNumber (ageOutPeriod.TotalSeconds).Handle);
-				handle = CMMemoryPoolCreate (dict.Handle);
+				Handle = CMMemoryPoolCreate (dict.Handle);
 			}
 		}
 #endif
@@ -54,26 +52,6 @@ namespace MonoMac.CoreMedia {
 		~CMMemoryPool ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
-		public IntPtr Handle { 
-			get {
-				return handle;
-			}
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -49,44 +49,21 @@ namespace MonoMac.CoreMedia {
 	}
 
 	[Since (4,0)]
-	public class CMSampleBuffer : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CMSampleBuffer : CFType {
 		internal CMSampleBuffer (IntPtr handle)
+			: this (handle, true)
 		{
-			this.handle = handle;
 		}
 
 		[Preserve (Conditional=true)]
 		internal CMSampleBuffer (IntPtr handle, bool owns)
+			: base (handle, owns) 
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-
-			this.handle = handle;
 		}
 		
 		~CMSampleBuffer ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #if !COREBUILD
@@ -113,9 +90,9 @@ namespace MonoMac.CoreMedia {
 
 			IntPtr buffer;
 			error = CMAudioSampleBufferCreateWithPacketDescriptions (IntPtr.Zero,
-				dataBuffer == null ? IntPtr.Zero : dataBuffer.handle,
+				dataBuffer == null ? IntPtr.Zero : dataBuffer.Handle,
 				true, IntPtr.Zero, IntPtr.Zero,
-				formatDescription.handle,
+				formatDescription.Handle,
 				samplesCount, sampleTimestamp,
 				packetDescriptions,
 				out buffer);
@@ -211,7 +188,7 @@ namespace MonoMac.CoreMedia {
 			error = CMSampleBufferCreateForImageBuffer (IntPtr.Zero,
 				imageBuffer.handle, dataReady,
 				IntPtr.Zero, IntPtr.Zero,
-				formatDescription.handle,
+				formatDescription.Handle,
 				ref sampleTiming,
 				out buffer);
 
@@ -228,7 +205,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferDataIsReady (handle);
+				return CMSampleBufferDataIsReady (Handle);
 			}
 		}
 
@@ -264,7 +241,7 @@ namespace MonoMac.CoreMedia {
 		
 		public CMBlockBuffer GetDataBuffer ()
 		{
-			var blockHandle = CMSampleBufferGetDataBuffer (handle);			
+			var blockHandle = CMSampleBufferGetDataBuffer (Handle);			
 			if (blockHandle == IntPtr.Zero)
 			{
 				return null;
@@ -282,7 +259,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetDecodeTimeStamp (handle);
+				return CMSampleBufferGetDecodeTimeStamp (Handle);
 			}
 		}
 
@@ -293,7 +270,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetDuration (handle);
+				return CMSampleBufferGetDuration (Handle);
 			}
 		}
 
@@ -304,7 +281,7 @@ namespace MonoMac.CoreMedia {
 		public CMFormatDescription GetFormatDescription ()
 		{
 			var desc = default(CMFormatDescription);
-			var descHandle = CMSampleBufferGetFormatDescription (handle);
+			var descHandle = CMSampleBufferGetFormatDescription (Handle);
 			if (descHandle != IntPtr.Zero)
 			{
 				desc = new CMFormatDescription (descHandle, false);
@@ -314,7 +291,7 @@ namespace MonoMac.CoreMedia {
 
 		public CMAudioFormatDescription GetAudioFormatDescription ()
 		{
-			var descHandle = CMSampleBufferGetFormatDescription (handle);
+			var descHandle = CMSampleBufferGetFormatDescription (Handle);
 			if (descHandle == IntPtr.Zero)
 				return null;
 
@@ -323,7 +300,7 @@ namespace MonoMac.CoreMedia {
 
 		public CMVideoFormatDescription GetVideoFormatDescription ()
 		{
-			var descHandle = CMSampleBufferGetFormatDescription (handle);
+			var descHandle = CMSampleBufferGetFormatDescription (Handle);
 			if (descHandle == IntPtr.Zero)
 				return null;
 
@@ -337,12 +314,12 @@ namespace MonoMac.CoreMedia {
 
 		public CVImageBuffer GetImageBuffer ()
 		{
-			IntPtr ib = CMSampleBufferGetImageBuffer (handle);
+			IntPtr ib = CMSampleBufferGetImageBuffer (Handle);
 			if (ib == IntPtr.Zero)
 				return null;
 
 			var ibt = CFType.GetTypeID (ib);
-			if (ibt == CVPixelBuffer.CVImageBufferType)
+			if (ibt == CVPixelBuffer.TypeID)
 				return new CVPixelBuffer (ib, false);
 			return new CVImageBuffer (ib, false);
 		}
@@ -356,7 +333,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetNumSamples (handle);
+				return CMSampleBufferGetNumSamples (Handle);
 			}
 		}
 
@@ -367,7 +344,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetOutputDecodeTimeStamp (handle);
+				return CMSampleBufferGetOutputDecodeTimeStamp (Handle);
 			}
 		}
 
@@ -378,7 +355,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetOutputDuration (handle);
+				return CMSampleBufferGetOutputDuration (Handle);
 			}
 		}
 
@@ -389,7 +366,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetOutputPresentationTimeStamp (handle);
+				return CMSampleBufferGetOutputPresentationTimeStamp (Handle);
 			}
 		}
 		
@@ -398,7 +375,7 @@ namespace MonoMac.CoreMedia {
 		
 		public int /*CMSampleBufferError*/ SetOutputPresentationTimeStamp (CMTime outputPresentationTimeStamp)
 		{
-			return (int)CMSampleBufferSetOutputPresentationTimeStamp (handle, outputPresentationTimeStamp);
+			return (int)CMSampleBufferSetOutputPresentationTimeStamp (Handle, outputPresentationTimeStamp);
 		}
 
 		/*[DllImport(Constants.CoreMediaLibrary)]
@@ -416,7 +393,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetPresentationTimeStamp (handle);
+				return CMSampleBufferGetPresentationTimeStamp (Handle);
 			}
 		}
 		
@@ -427,7 +404,7 @@ namespace MonoMac.CoreMedia {
 		
 		public CMSampleBufferAttachmentSettings [] GetSampleAttachments (bool createIfNecessary)
 		{
-			var cfArrayRef = CMSampleBufferGetSampleAttachmentsArray (handle, createIfNecessary);
+			var cfArrayRef = CMSampleBufferGetSampleAttachmentsArray (Handle, createIfNecessary);
 			if (cfArrayRef == IntPtr.Zero)
 			{
 				return new CMSampleBufferAttachmentSettings [0];
@@ -445,7 +422,7 @@ namespace MonoMac.CoreMedia {
 		
 		public uint GetSampleSize (int sampleIndex)
 		{
-			return CMSampleBufferGetSampleSize (handle, sampleIndex);
+			return CMSampleBufferGetSampleSize (Handle, sampleIndex);
 		}
 		
 		/*[DllImport(Constants.CoreMediaLibrary)]
@@ -484,10 +461,10 @@ namespace MonoMac.CoreMedia {
 
 			status = 0;
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				return null;
 
-			if ((status = CMSampleBufferGetSampleTimingInfoArray (handle, 0, null, out count)) != 0)
+			if ((status = CMSampleBufferGetSampleTimingInfoArray (Handle, 0, null, out count)) != 0)
 				return null;
 
 			CMSampleTimingInfo [] pInfo = new CMSampleTimingInfo [count];
@@ -496,7 +473,7 @@ namespace MonoMac.CoreMedia {
 				return pInfo;
 
 			fixed (CMSampleTimingInfo* info = pInfo)
-				if ((status = CMSampleBufferGetSampleTimingInfoArray (handle, count, info, out count)) != 0)
+				if ((status = CMSampleBufferGetSampleTimingInfoArray (Handle, count, info, out count)) != 0)
 					return null;
 
 			return pInfo;
@@ -515,16 +492,15 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferGetTotalSampleSize (handle);
+				return CMSampleBufferGetTotalSampleSize (Handle);
 			}
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
-		extern static int CMSampleBufferGetTypeID ();
+		extern static uint CMSampleBufferGetTypeID ();
 		
-		public static int GetTypeID ()
-		{
-			return CMSampleBufferGetTypeID ();
+		public static uint TypeID {
+			get { return CMSampleBufferGetTypeID (); }
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -532,7 +508,7 @@ namespace MonoMac.CoreMedia {
 		
 		public int /*CMSampleBufferError*/ Invalidate()
 		{
-			return (int)CMSampleBufferInvalidate (handle);
+			return (int)CMSampleBufferInvalidate (Handle);
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -542,7 +518,7 @@ namespace MonoMac.CoreMedia {
 		{
 			get
 			{
-				return CMSampleBufferIsValid (handle);
+				return CMSampleBufferIsValid (Handle);
 			}
 		}
 		
@@ -551,7 +527,7 @@ namespace MonoMac.CoreMedia {
 		
 		public int /*CMSampleBufferError*/ MakeDataReady ()
 		{
-			return (int)CMSampleBufferMakeDataReady (handle);
+			return (int)CMSampleBufferMakeDataReady (Handle);
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -562,9 +538,9 @@ namespace MonoMac.CoreMedia {
 			var dataBufferHandle = IntPtr.Zero;
 			if (dataBuffer != null)
 			{
-				dataBufferHandle = dataBuffer.handle;
+				dataBufferHandle = dataBuffer.Handle;
 			}
-			return (int)CMSampleBufferSetDataBuffer (handle, dataBufferHandle);
+			return (int)CMSampleBufferSetDataBuffer (Handle, dataBufferHandle);
 		}
 		
 		/*[DllImport(Constants.CoreMediaLibrary)]
@@ -581,7 +557,7 @@ namespace MonoMac.CoreMedia {
 		
 		public int/*CMSampleBufferError*/ SetDataReady ()
 		{
-			return (int)CMSampleBufferSetDataReady (handle);
+			return (int)CMSampleBufferSetDataReady (Handle);
 		}
 		
 		/*[DllImport(Constants.CoreMediaLibrary)]
@@ -598,9 +574,9 @@ namespace MonoMac.CoreMedia {
 		{
 			var handleToTrack = IntPtr.Zero;
 			if (bufferToTrack != null) {
-				handleToTrack = bufferToTrack.handle;
+				handleToTrack = bufferToTrack.Handle;
 			}
-			return (int)CMSampleBufferTrackDataReadiness (handle, handleToTrack);
+			return (int)CMSampleBufferTrackDataReadiness (Handle, handleToTrack);
 		}
 
 	}

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -134,7 +134,7 @@ namespace MonoMac.CoreMedia {
 			if (error != CMTimebaseError.None)
 				throw new ArgumentException (error.ToString ());
 
-			CFObject.CFRetain (Handle);
+			CFType.Retain (Handle);
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -149,7 +149,7 @@ namespace MonoMac.CoreMedia {
 			if (error != CMTimebaseError.None)
 				throw new ArgumentException (error.ToString ());
 
-			CFObject.CFRetain (Handle);
+			CFType.Retain (Handle);
 		}
 
 
@@ -366,7 +366,7 @@ namespace MonoMac.CoreMedia {
 		internal CMClockOrTimebase (IntPtr handle, bool owns)
 		{
 			if (!owns)
-				CFObject.CFRetain (Handle);
+				CFType.Retain (Handle);
 			this.handle = handle;
 		}
 
@@ -384,7 +384,7 @@ namespace MonoMac.CoreMedia {
 		protected virtual void Dispose (bool disposing)
 		{
 			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
+				CFType.Release (Handle);
 				handle = IntPtr.Zero;
 			}
 		}

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -356,7 +356,7 @@ namespace MonoMac.CoreMidi {
 			code = MIDIObjectGetStringProperty (handle, property, out val);
 			if (code == 0){
 				var ret = NSString.FromHandle (val);
-				CFObject.CFRelease (val);
+				CFType.Release (val);
 				return ret;
 			}
 			return null;

--- a/src/CoreServices/CFHTTPAuthentication.cs
+++ b/src/CoreServices/CFHTTPAuthentication.cs
@@ -35,54 +35,27 @@ using MonoMac.ObjCRuntime;
 
 namespace MonoMac.CoreServices {
 
-	public class CFHTTPAuthentication : CFType, INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CFHTTPAuthentication : CFType {
 		internal CFHTTPAuthentication (IntPtr handle)
 			: this (handle, false)
 		{
 		}
 
 		internal CFHTTPAuthentication (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
 		}
 
-		[DllImport (Constants.CFNetworkLibrary, EntryPoint="CFHTTPAuthenticationGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.CFNetworkLibrary)]
+		extern static uint CFHTTPAuthenticationGetTypeID ();
+
+		public static uint TypeID {
+			get { return CFHTTPAuthenticationGetTypeID (); }
+		}
 
 		~CFHTTPAuthentication ()
 		{
 			Dispose (false);
-		}
-		
-		protected void CheckHandle ()
-		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException (GetType ().Name);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get {
-				CheckHandle ();
-				return handle;
-			}
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
@@ -104,7 +77,10 @@ namespace MonoMac.CoreServices {
 		extern static bool CFHTTPAuthenticationIsValid (IntPtr handle, IntPtr error);
 
 		public bool IsValid {
-			get { return CFHTTPAuthenticationIsValid (Handle, IntPtr.Zero); }
+			get {
+				ThrowIfDisposed ();
+				return CFHTTPAuthenticationIsValid (Handle, IntPtr.Zero);
+			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
@@ -112,6 +88,7 @@ namespace MonoMac.CoreServices {
 
 		public bool AppliesToRequest (CFHTTPMessage request)
 		{
+			ThrowIfDisposed ();
 			if (!request.IsRequest)
 				throw new InvalidOperationException ();
 
@@ -122,21 +99,30 @@ namespace MonoMac.CoreServices {
 		extern static bool CFHTTPAuthenticationRequiresAccountDomain (IntPtr handle);
 
 		public bool RequiresAccountDomain {
-			get { return CFHTTPAuthenticationRequiresAccountDomain (Handle); }
+			get {
+				ThrowIfDisposed ();
+				return CFHTTPAuthenticationRequiresAccountDomain (Handle);
+			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static bool CFHTTPAuthenticationRequiresOrderedRequests (IntPtr handle);
 
 		public bool RequiresOrderedRequests {
-			get { return CFHTTPAuthenticationRequiresOrderedRequests (Handle); }
+			get {
+				ThrowIfDisposed ();
+				return CFHTTPAuthenticationRequiresOrderedRequests (Handle);
+			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static bool CFHTTPAuthenticationRequiresUserNameAndPassword (IntPtr handle);
 
 		public bool RequiresUserNameAndPassword {
-			get { return CFHTTPAuthenticationRequiresUserNameAndPassword (Handle); }
+			get {
+				ThrowIfDisposed ();
+				return CFHTTPAuthenticationRequiresUserNameAndPassword (Handle);
+			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
@@ -144,6 +130,7 @@ namespace MonoMac.CoreServices {
 
 		public string GetMethod ()
 		{
+			ThrowIfDisposed ();
 			var ptr = CFHTTPAuthenticationCopyMethod (Handle);
 			if (ptr == IntPtr.Zero)
 				return null;

--- a/src/CoreServices/CFHTTPStream.cs
+++ b/src/CoreServices/CFHTTPStream.cs
@@ -88,8 +88,8 @@ namespace MonoMac.CoreServices {
 				if (handle == IntPtr.Zero)
 					return null;
 
-				if (CFType.GetTypeID (handle) != CFUrl.GetTypeID ()) {
-					CFObject.CFRelease (handle);
+				if (CFType.GetTypeID (handle) != CFUrl.TypeID) {
+					CFType.Release (handle);
 					throw new InvalidCastException ();
 				}
 
@@ -104,8 +104,8 @@ namespace MonoMac.CoreServices {
 			if (handle == IntPtr.Zero)
 				return null;
 
-			if (CFType.GetTypeID (handle) != CFHTTPMessage.GetTypeID ()) {
-				CFObject.CFRelease (handle);
+			if (CFType.GetTypeID (handle) != CFHTTPMessage.TypeID) {
+				CFType.Release (handle);
 				throw new InvalidCastException ();
 			}
 
@@ -118,8 +118,8 @@ namespace MonoMac.CoreServices {
 			if (handle == IntPtr.Zero)
 				return null;
 
-			if (CFType.GetTypeID (handle) != CFHTTPMessage.GetTypeID ()) {
-				CFObject.CFRelease (handle);
+			if (CFType.GetTypeID (handle) != CFHTTPMessage.TypeID) {
+				CFType.Release (handle);
 				throw new InvalidCastException ();
 			}
 			return new CFHTTPMessage (handle);

--- a/src/CoreServices/CFHost.cs
+++ b/src/CoreServices/CFHost.cs
@@ -36,35 +36,15 @@ using MonoMac.ObjCRuntime;
 
 namespace MonoMac.CoreServices {
 
-	class CFHost : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	class CFHost : CFType {
 		CFHost (IntPtr handle)
+			: base (handle, true)
 		{
-			this.handle = handle;
 		}
 
 		~CFHost ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]

--- a/src/CoreText/CTFont.Generator.cs
+++ b/src/CoreText/CTFont.Generator.cs
@@ -36,46 +36,20 @@ using MonoMac.Foundation;
 
 namespace MonoMac.CoreText {
 
-	public partial class CTFont : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public partial class CTFont : CFType {
 		internal CTFont (IntPtr handle)
 			: this (handle, false)
 		{
 		}
 
 		internal CTFont (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero) {
-				GC.SuppressFinalize (this);
-				throw new ArgumentNullException ("handle");
-			}
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		~CTFont ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 	}
 }

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1538,8 +1538,8 @@ namespace MonoMac.CoreText {
 			if (name == null)
 				throw ConstructorError.ArgumentNull (this, "name");
 			using (NSString n = new NSString (name))
-				handle = CTFontCreateWithName (n.Handle, size, IntPtr.Zero);
-			if (handle == IntPtr.Zero)
+				Handle = CTFontCreateWithName (n.Handle, size, IntPtr.Zero);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1550,8 +1550,8 @@ namespace MonoMac.CoreText {
 			if (name == null)
 				throw ConstructorError.ArgumentNull (this, "name");
 			using (CFString n = name)
-				handle = CTFontCreateWithName (n.Handle, size, ref matrix);
-			if (handle == IntPtr.Zero)
+				Handle = CTFontCreateWithName (n.Handle, size, ref matrix);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1561,8 +1561,8 @@ namespace MonoMac.CoreText {
 		{
 			if (descriptor == null)
 				throw ConstructorError.ArgumentNull (this, "descriptor");
-			handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, IntPtr.Zero);
-			if (handle == IntPtr.Zero)
+			Handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, IntPtr.Zero);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1572,8 +1572,8 @@ namespace MonoMac.CoreText {
 		{
 			if (descriptor == null)
 				throw ConstructorError.ArgumentNull (this, "descriptor");
-			handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, ref matrix);
-			if (handle == IntPtr.Zero)
+			Handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, ref matrix);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1584,8 +1584,8 @@ namespace MonoMac.CoreText {
 			if (name == null)
 				throw ConstructorError.ArgumentNull (this, "name");
 			using (CFString n = name)
-				handle = CTFontCreateWithNameAndOptions (n.Handle, size, IntPtr.Zero, options);
-			if (handle == IntPtr.Zero)
+				Handle = CTFontCreateWithNameAndOptions (n.Handle, size, IntPtr.Zero, options);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1596,8 +1596,8 @@ namespace MonoMac.CoreText {
 			if (name == null)
 				throw ConstructorError.ArgumentNull (this, "name");
 			using (CFString n = name)
-				handle = CTFontCreateWithNameAndOptions (n.Handle, size, ref matrix, options);
-			if (handle == IntPtr.Zero)
+				Handle = CTFontCreateWithNameAndOptions (n.Handle, size, ref matrix, options);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1607,9 +1607,9 @@ namespace MonoMac.CoreText {
 		{
 			if (descriptor == null)
 				throw ConstructorError.ArgumentNull (this, "descriptor");
-			handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle,
+			Handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle,
 					size, IntPtr.Zero, options);
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1619,9 +1619,9 @@ namespace MonoMac.CoreText {
 		{
 			if (descriptor == null)
 				throw ConstructorError.ArgumentNull (this, "descriptor");
-			handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle,
+			Handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle,
 					size, ref matrix, options);
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1635,8 +1635,8 @@ namespace MonoMac.CoreText {
 		{
 			if (font == null)
 				throw new ArgumentNullException ("font");
-			handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, descriptor == null ? IntPtr.Zero : descriptor.Handle);
-			if (handle == IntPtr.Zero)
+			Handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, descriptor == null ? IntPtr.Zero : descriptor.Handle);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1644,8 +1644,8 @@ namespace MonoMac.CoreText {
 		{
 			if (font == null)
 				throw new ArgumentNullException ("font");
-			handle = CTFontCreateWithGraphicsFont2 (font.Handle, size, IntPtr.Zero, descriptor == null ? IntPtr.Zero : descriptor.Handle);
-			if (handle == IntPtr.Zero)
+			Handle = CTFontCreateWithGraphicsFont2 (font.Handle, size, IntPtr.Zero, descriptor == null ? IntPtr.Zero : descriptor.Handle);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1653,8 +1653,8 @@ namespace MonoMac.CoreText {
 		{
 			if (font == null)
 				throw new ArgumentNullException ("font");
-			handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, IntPtr.Zero);
-			if (handle == IntPtr.Zero)
+			Handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, IntPtr.Zero);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 		
@@ -1665,8 +1665,8 @@ namespace MonoMac.CoreText {
 			if (language == null)
 				throw ConstructorError.ArgumentNull (this, "language");
 			using (CFString l = language)
-				handle = CTFontCreateUIFontForLanguage (uiType, size, l.Handle);
-			if (handle == IntPtr.Zero)
+				Handle = CTFontCreateUIFontForLanguage (uiType, size, l.Handle);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -1676,7 +1676,7 @@ namespace MonoMac.CoreText {
 		{
 			if (attributes == null)
 				throw new ArgumentNullException ("attributes");
-			return CreateFont (CTFontCreateCopyWithAttributes (handle, size, IntPtr.Zero, attributes.Handle));
+			return CreateFont (CTFontCreateCopyWithAttributes (Handle, size, IntPtr.Zero, attributes.Handle));
 		}
 
 		static CTFont CreateFont (IntPtr h)
@@ -1692,7 +1692,7 @@ namespace MonoMac.CoreText {
 		{
 			if (attributes == null)
 				throw new ArgumentNullException ("attributes");
-			return CreateFont (CTFontCreateCopyWithAttributes (handle, size, ref matrix, attributes.Handle));
+			return CreateFont (CTFontCreateCopyWithAttributes (Handle, size, ref matrix, attributes.Handle));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1700,7 +1700,7 @@ namespace MonoMac.CoreText {
 		public CTFont WithSymbolicTraits (float size, CTFontSymbolicTraits symTraitValue, CTFontSymbolicTraits symTraitMask)
 		{
 			return CreateFont (
-					CTFontCreateCopyWithSymbolicTraits (handle, size, IntPtr.Zero, symTraitValue, symTraitMask));
+					CTFontCreateCopyWithSymbolicTraits (Handle, size, IntPtr.Zero, symTraitValue, symTraitMask));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1708,7 +1708,7 @@ namespace MonoMac.CoreText {
 		public CTFont WithSymbolicTraits (float size, CTFontSymbolicTraits symTraitValue, CTFontSymbolicTraits symTraitMask, ref CGAffineTransform matrix)
 		{
 			return CreateFont (
-					CTFontCreateCopyWithSymbolicTraits (handle, size, ref matrix, symTraitValue, symTraitMask));
+					CTFontCreateCopyWithSymbolicTraits (Handle, size, ref matrix, symTraitValue, symTraitMask));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1718,7 +1718,7 @@ namespace MonoMac.CoreText {
 			if (family == null)
 				throw new ArgumentNullException ("family");
 			using (CFString f = family)
-				return CreateFont (CTFontCreateCopyWithFamily (handle, size, IntPtr.Zero, f.Handle));
+				return CreateFont (CTFontCreateCopyWithFamily (Handle, size, IntPtr.Zero, f.Handle));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1728,7 +1728,7 @@ namespace MonoMac.CoreText {
 			if (family == null)
 				throw new ArgumentNullException ("family");
 			using (CFString f = family)
-				return CreateFont (CTFontCreateCopyWithFamily (handle, size, ref matrix, f.Handle));
+				return CreateFont (CTFontCreateCopyWithFamily (Handle, size, ref matrix, f.Handle));
 		}
 
 #endregion
@@ -1742,7 +1742,7 @@ namespace MonoMac.CoreText {
 			if (value == null)
 				throw new ArgumentNullException ("value");
 			using (CFString v = value)
-				return CreateFont (CTFontCreateForString (handle, v.Handle, range));
+				return CreateFont (CTFontCreateForString (Handle, v.Handle, range));
 		}
 
 #endregion
@@ -1753,7 +1753,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyFontDescriptor (IntPtr font);
 		public CTFontDescriptor GetFontDescriptor ()
 		{
-			var h = CTFontCopyFontDescriptor (handle);
+			var h = CTFontCopyFontDescriptor (Handle);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CTFontDescriptor (h, true);
@@ -1765,32 +1765,32 @@ namespace MonoMac.CoreText {
 		{
 			if (attribute == null)
 				throw new ArgumentNullException ("attribute");
-			return Runtime.GetNSObject (CTFontCopyAttribute (handle, attribute.Handle));
+			return Runtime.GetNSObject (CTFontCopyAttribute (Handle, attribute.Handle));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetSize (IntPtr font);
 		public float Size {
-			get {return CTFontGetSize (handle);}
+			get {return CTFontGetSize (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CGAffineTransform CTFontGetMatrix (IntPtr font);
 		public CGAffineTransform Matrix {
-			get {return CTFontGetMatrix (handle);}
+			get {return CTFontGetMatrix (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CTFontSymbolicTraits CTFontGetSymbolicTraits (IntPtr font);
 		public CTFontSymbolicTraits SymbolicTraits {
-			get {return CTFontGetSymbolicTraits (handle);}
+			get {return CTFontGetSymbolicTraits (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyTraits (IntPtr font);
 		public CTFontTraits GetTraits ()
 		{
-			var d = (NSDictionary) Runtime.GetNSObject (CTFontCopyTraits (handle));
+			var d = (NSDictionary) Runtime.GetNSObject (CTFontCopyTraits (Handle));
 			if (d == null)
 				return null;
 			d.Release ();
@@ -1811,39 +1811,39 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyPostScriptName (IntPtr font);
 		public string PostScriptName {
-			get {return GetStringAndRelease (CTFontCopyPostScriptName (handle));}
+			get {return GetStringAndRelease (CTFontCopyPostScriptName (Handle));}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyFamilyName (IntPtr font);
 		public string FamilyName {
-			get {return GetStringAndRelease (CTFontCopyFamilyName (handle));}
+			get {return GetStringAndRelease (CTFontCopyFamilyName (Handle));}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyFullName (IntPtr font);
 		public string FullName {
-			get {return GetStringAndRelease (CTFontCopyFullName (handle));}
+			get {return GetStringAndRelease (CTFontCopyFullName (Handle));}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyDisplayName (IntPtr font);
 		public string DisplayName {
-			get {return GetStringAndRelease (CTFontCopyDisplayName (handle));}
+			get {return GetStringAndRelease (CTFontCopyDisplayName (Handle));}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyName (IntPtr font, IntPtr nameKey);
 		public string GetName (CTFontNameKey nameKey)
 		{
-			return GetStringAndRelease (CTFontCopyName (handle, CTFontNameKeyId.ToId (nameKey).Handle));
+			return GetStringAndRelease (CTFontCopyName (Handle, CTFontNameKeyId.ToId (nameKey).Handle));
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyLocalizedName (IntPtr font, IntPtr nameKey);
 		public string GetLocalizedName (CTFontNameKey nameKey)
 		{
-			return GetStringAndRelease (CTFontCopyLocalizedName (handle, CTFontNameKeyId.ToId (nameKey).Handle));
+			return GetStringAndRelease (CTFontCopyLocalizedName (Handle, CTFontNameKeyId.ToId (nameKey).Handle));
 		}
 #endregion
 
@@ -1852,7 +1852,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyCharacterSet (IntPtr font);
 		public NSCharacterSet CharacterSet {
 			get {
-				var cs = (NSCharacterSet) Runtime.GetNSObject (CTFontCopyCharacterSet (handle));
+				var cs = (NSCharacterSet) Runtime.GetNSObject (CTFontCopyCharacterSet (Handle));
 				if (cs == null)
 					return null;
 				cs.Release ();
@@ -1863,18 +1863,18 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern uint CTFontGetStringEncoding (IntPtr font);
 		public uint StringEncoding {
-			get {return CTFontGetStringEncoding (handle);}
+			get {return CTFontGetStringEncoding (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopySupportedLanguages (IntPtr font);
 		public string[] GetSupportedLanguages ()
 		{
-			var cfArrayRef = CTFontCopySupportedLanguages (handle);
+			var cfArrayRef = CTFontCopySupportedLanguages (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new string [0];
 			var languages = NSArray.ArrayFromHandle<string> (cfArrayRef, CFString.FetchString);
-			CFObject.CFRelease (cfArrayRef);
+			CFType.Release (cfArrayRef);
 			return languages;
 		}
 
@@ -1886,7 +1886,7 @@ namespace MonoMac.CoreText {
 			AssertLength ("characters", characters, count);
 			AssertLength ("glyphs",     characters, count);
 
-			return CTFontGetGlyphsForCharacters (handle, characters, glyphs, count);
+			return CTFontGetGlyphsForCharacters (Handle, characters, glyphs, count);
 		}
 
 		public bool GetGlyphsForCharacters (char[] characters, CGGlyph[] glyphs)
@@ -1920,67 +1920,67 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetAscent (IntPtr font);
 		public float AscentMetric {
-			get {return CTFontGetAscent (handle);}
+			get {return CTFontGetAscent (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetDescent (IntPtr font);
 		public float DescentMetric {
-			get {return CTFontGetDescent (handle);}
+			get {return CTFontGetDescent (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetLeading (IntPtr font);
 		public float LeadingMetric {
-			get {return CTFontGetLeading (handle);}
+			get {return CTFontGetLeading (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern uint CTFontGetUnitsPerEm (IntPtr font);
 		public uint UnitsPerEmMetric {
-			get {return CTFontGetUnitsPerEm (handle);}
+			get {return CTFontGetUnitsPerEm (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern int CTFontGetGlyphCount (IntPtr font);
 		public int GlyphCount {
-			get {return CTFontGetGlyphCount (handle);}
+			get {return CTFontGetGlyphCount (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern RectangleF CTFontGetBoundingBox (IntPtr font);
 		public RectangleF BoundingBox {
-			get {return CTFontGetBoundingBox (handle);}
+			get {return CTFontGetBoundingBox (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetUnderlinePosition (IntPtr font);
 		public float UnderlinePosition {
-			get {return CTFontGetUnderlinePosition (handle);}
+			get {return CTFontGetUnderlinePosition (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetUnderlineThickness (IntPtr font);
 		public float UnderlineThickness {
-			get {return CTFontGetUnderlineThickness (handle);}
+			get {return CTFontGetUnderlineThickness (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetSlantAngle (IntPtr font);
 		public float SlantAngle {
-			get {return CTFontGetSlantAngle (handle);}
+			get {return CTFontGetSlantAngle (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetCapHeight (IntPtr font);
 		public float CapHeightMetric {
-			get {return CTFontGetCapHeight (handle);}
+			get {return CTFontGetCapHeight (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTFontGetXHeight (IntPtr font);
 		public float XHeightMetric {
-			get {return CTFontGetXHeight (handle);}
+			get {return CTFontGetXHeight (Handle);}
 		}
 #endregion
 
@@ -1992,7 +1992,7 @@ namespace MonoMac.CoreText {
 			if (glyphName == null)
 				throw new ArgumentNullException ("glyphName");
 			using (NSString n = new NSString (glyphName))
-				return CTFontGetGlyphWithName (handle, n.Handle);
+				return CTFontGetGlyphWithName (Handle, n.Handle);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -2003,7 +2003,7 @@ namespace MonoMac.CoreText {
 			AssertLength ("glyphs",         glyphs, count);
 			AssertLength ("boundingRects",  boundingRects, count, true);
 
-			return CTFontGetBoundingRectsForGlyphs (handle, orientation, glyphs, boundingRects, count);
+			return CTFontGetBoundingRectsForGlyphs (Handle, orientation, glyphs, boundingRects, count);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -2015,7 +2015,7 @@ namespace MonoMac.CoreText {
 			AssertLength ("glyphs",         glyphs, count);
 			AssertLength ("boundingRects",  boundingRects, count, true);
 
-			return CTFontGetOpticalBoundsForGlyphs (handle, glyphs, boundingRects, count, 0);
+			return CTFontGetOpticalBoundsForGlyphs (Handle, glyphs, boundingRects, count, 0);
 		}
 
 		public RectangleF GetBoundingRects (CTFontOrientation orientation, CGGlyph[] glyphs)
@@ -2033,7 +2033,7 @@ namespace MonoMac.CoreText {
 			AssertLength ("glyphs",   glyphs, count);
 			AssertLength ("advances", advances, count, true);
 
-			return CTFontGetAdvancesForGlyphs (handle, orientation, glyphs, advances, count);
+			return CTFontGetAdvancesForGlyphs (Handle, orientation, glyphs, advances, count);
 		}
 
 		public double GetAdvancesForGlyphs (CTFontOrientation orientation, CGGlyph[] glyphs)
@@ -2051,14 +2051,14 @@ namespace MonoMac.CoreText {
 			AssertLength ("glyphs",       glyphs, count);
 			AssertLength ("translations", translations, count);
 
-			CTFontGetVerticalTranslationsForGlyphs (handle, glyphs, translations, count);
+			CTFontGetVerticalTranslationsForGlyphs (Handle, glyphs, translations, count);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCreatePathForGlyph (IntPtr font, CGGlyph glyph, IntPtr transform);
 		public CGPath GetPathForGlyph (CGGlyph glyph)
 		{
-			var h = CTFontCreatePathForGlyph (handle, glyph, IntPtr.Zero);
+			var h = CTFontCreatePathForGlyph (Handle, glyph, IntPtr.Zero);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CGPath (h, true);
@@ -2068,7 +2068,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCreatePathForGlyph (IntPtr font, CGGlyph glyph, ref CGAffineTransform transform);
 		public CGPath GetPathForGlyph (CGGlyph glyph, ref CGAffineTransform transform)
 		{
-			var h = CTFontCreatePathForGlyph (handle, glyph, ref transform);
+			var h = CTFontCreatePathForGlyph (Handle, glyph, ref transform);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CGPath (h, true);
@@ -2089,7 +2089,7 @@ namespace MonoMac.CoreText {
 			int gl = glyphs.Length;
 			if (gl != positions.Length)
 				throw new ArgumentException ("array sizes fo context and glyphs differ");
-			CTFontDrawGlyphs (handle, glyphs, positions, gl, context.Handle);
+			CTFontDrawGlyphs (Handle, glyphs, positions, gl, context.Handle);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -2100,7 +2100,7 @@ namespace MonoMac.CoreText {
 		{
 			if (positions == null)
 				throw new ArgumentNullException ("positions");
-			return CTFontGetLigatureCaretPositions (handle, glyph, positions, positions.Length);
+			return CTFontGetLigatureCaretPositions (Handle, glyph, positions, positions.Length);
 		}
 #endregion
 
@@ -2109,12 +2109,12 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyVariationAxes (IntPtr font);
 		public CTFontVariationAxes[] GetVariationAxes ()
 		{
-			var cfArrayRef = CTFontCopyVariationAxes (handle);
+			var cfArrayRef = CTFontCopyVariationAxes (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTFontVariationAxes [0];
 			var axes = NSArray.ArrayFromHandle (cfArrayRef,
 					d => new CTFontVariationAxes ((NSDictionary) Runtime.GetNSObject (d)));
-			CFObject.CFRelease (cfArrayRef);
+			CFType.Release (cfArrayRef);
 			return axes;
 		}
 
@@ -2122,7 +2122,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyVariation (IntPtr font);
 		public CTFontVariation GetVariation ()
 		{
-			var cfDictionaryRef = CTFontCopyVariation (handle);
+			var cfDictionaryRef = CTFontCopyVariation (Handle);
 			if (cfDictionaryRef == IntPtr.Zero)
 				return null;
 			return new CTFontVariation ((NSDictionary) Runtime.GetNSObject (cfDictionaryRef));
@@ -2136,12 +2136,12 @@ namespace MonoMac.CoreText {
 		// Always returns only default features
 		public CTFontFeatures[] GetFeatures ()
 		{
-			var cfArrayRef = CTFontCopyFeatures (handle);
+			var cfArrayRef = CTFontCopyFeatures (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTFontFeatures [0];
 			var features = NSArray.ArrayFromHandle (cfArrayRef,
 					d => new CTFontFeatures ((NSDictionary) Runtime.GetNSObject (d)));
-			CFObject.CFRelease (cfArrayRef);
+			CFType.Release (cfArrayRef);
 			return features;
 		}
 
@@ -2150,12 +2150,12 @@ namespace MonoMac.CoreText {
 
 		public CTFontFeatureSettings[] GetFeatureSettings ()
 		{
-			var cfArrayRef = CTFontCopyFeatureSettings (handle);
+			var cfArrayRef = CTFontCopyFeatureSettings (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTFontFeatureSettings [0];
 			var featureSettings = NSArray.ArrayFromHandle (cfArrayRef,
 					d => new CTFontFeatureSettings ((NSDictionary) Runtime.GetNSObject (d)));
-			CFObject.CFRelease (cfArrayRef);
+			CFType.Release (cfArrayRef);
 			return featureSettings;
 		}
 #endregion
@@ -2165,7 +2165,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyGraphicsFont (IntPtr font, IntPtr attributes);
 		public CGFont ToCGFont (CTFontDescriptor attributes)
 		{
-			var h = CTFontCopyGraphicsFont (handle, attributes == null ? IntPtr.Zero : attributes.Handle);
+			var h = CTFontCopyGraphicsFont (Handle, attributes == null ? IntPtr.Zero : attributes.Handle);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CGFont (h, true);
@@ -2182,13 +2182,13 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyAvailableTables (IntPtr font, CTFontTableOptions options);
 		public CTFontTable[] GetAvailableTables (CTFontTableOptions options)
 		{
-			var cfArrayRef = CTFontCopyAvailableTables (handle, options);
+			var cfArrayRef = CTFontCopyAvailableTables (Handle, options);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTFontTable [0];
 			var tables = NSArray.ArrayFromHandle (cfArrayRef, v => {
 					return (CTFontTable) (uint) v;
 			});
-			CFObject.CFRelease (cfArrayRef);
+			CFType.Release (cfArrayRef);
 			return tables;
 		}
 
@@ -2196,7 +2196,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFontCopyTable (IntPtr font, CTFontTable table, CTFontTableOptions options);
 		public NSData GetFontTableData (CTFontTable table, CTFontTableOptions options)
 		{
-			IntPtr cfDataRef = CTFontCopyTable (handle, table, options);
+			IntPtr cfDataRef = CTFontCopyTable (Handle, table, options);
 			if (cfDataRef == IntPtr.Zero)
 				return null;
 			var d = new NSData (cfDataRef);
@@ -2206,7 +2206,7 @@ namespace MonoMac.CoreText {
 #endregion
 
 #region
-		[DllImport (Constants.CoreTextLibrary, EntryPoint="CTFontGetTypeID")]
+		[DllImport (Constants.CoreTextLibrary)]
 		extern static IntPtr CTFontCopyDefaultCascadeListForLanguages (IntPtr font, IntPtr languagePrefList);
 
 		[Since (6,0)]
@@ -2215,7 +2215,7 @@ namespace MonoMac.CoreText {
 			if (languages == null)
 				throw new ArgumentNullException ("languages");
 			using (var arr = NSArray.FromStrings (languages)){
-				using (var retArray = new CFArray (CTFontCopyDefaultCascadeListForLanguages (handle, arr.Handle), true)){
+				using (var retArray = new CFArray (CTFontCopyDefaultCascadeListForLanguages (Handle, arr.Handle), true)){
 					int n = retArray.Count;
 
 					var ret = new CTFontDescriptor [n];
@@ -2233,7 +2233,11 @@ namespace MonoMac.CoreText {
 			return FullName;
 		}
 
-		[DllImport (Constants.CoreTextLibrary, EntryPoint="CTFontGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.CoreTextLibrary)]
+		extern static uint CTFontGetTypeID ();
+
+		public static uint TypeID {
+			get { return CTFontGetTypeID (); }
+		}
 	}
 }

--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -111,39 +111,15 @@ namespace MonoMac.CoreText {
 	}
 
 	[Since (3,2)]
-	public class CTFrame : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTFrame : CFType {
 		internal CTFrame (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get { return handle; }
 		}
 
 		~CTFrame ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -153,12 +129,12 @@ namespace MonoMac.CoreText {
 		
 		public NSRange GetStringRange ()
 		{
-			return CTFrameGetStringRange (handle);
+			return CTFrameGetStringRange (Handle);
 		}
 
 		public NSRange GetVisibleStringRange ()
 		{
-			return CTFrameGetVisibleStringRange (handle);
+			return CTFrameGetVisibleStringRange (Handle);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -166,7 +142,7 @@ namespace MonoMac.CoreText {
 		
 		public CGPath GetPath ()
 		{
-			IntPtr h = CTFrameGetPath (handle);
+			IntPtr h = CTFrameGetPath (Handle);
 			return h == IntPtr.Zero ? null : new CGPath (h, false);
 		}
 
@@ -175,7 +151,7 @@ namespace MonoMac.CoreText {
 
 		public CTFrameAttributes GetFrameAttributes ()
 		{
-			var attrs = (NSDictionary) Runtime.GetNSObject (CTFrameGetFrameAttributes (handle));
+			var attrs = (NSDictionary) Runtime.GetNSObject (CTFrameGetFrameAttributes (Handle));
 			return attrs == null ? null : new CTFrameAttributes (attrs);
 		}
 		
@@ -184,7 +160,7 @@ namespace MonoMac.CoreText {
 
 		public CTLine [] GetLines ()
 		{
-			var cfArrayRef = CTFrameGetLines (handle);
+			var cfArrayRef = CTFrameGetLines (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTLine [0];
 
@@ -202,9 +178,9 @@ namespace MonoMac.CoreText {
 				throw new ArgumentNullException ("origins");
 			if (range.Length != 0 && origins.Length < range.Length)
 				throw new ArgumentException ("origins must contain at least range.Length elements.", "origins");
-			else if (origins.Length < CFArray.GetCount (CTFrameGetLines (handle)))
+			else if (origins.Length < CFArray.GetCount (CTFrameGetLines (Handle)))
 				throw new ArgumentException ("origins must contain at least GetLines().Length elements.", "origins");
-			CTFrameGetLineOrigins (handle, range, origins);
+			CTFrameGetLineOrigins (Handle, range, origins);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -215,7 +191,7 @@ namespace MonoMac.CoreText {
 			if (ctx == null)
 				throw new ArgumentNullException ("ctx");
 
-			CTFrameDraw (handle, ctx.Handle);
+			CTFrameDraw (Handle, ctx.Handle);
 		}
 	}
 }

--- a/src/CoreText/CTFramesetter.cs
+++ b/src/CoreText/CTFramesetter.cs
@@ -36,40 +36,15 @@ using MonoMac.CoreGraphics;
 namespace MonoMac.CoreText {
 
 	[Since (3,2)]
-	public class CTFramesetter : INativeObject, IDisposable {
-
-		internal IntPtr handle;
-
+	public class CTFramesetter : CFType {
 		internal CTFramesetter (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
 		~CTFramesetter ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Framesetter Creation
@@ -79,8 +54,8 @@ namespace MonoMac.CoreText {
 		{
 			if (value == null)
 				throw ConstructorError.ArgumentNull (this, "value");
-			handle = CTFramesetterCreateWithAttributedString (value.Handle);
-			if (handle == IntPtr.Zero)
+			Handle = CTFramesetterCreateWithAttributedString (value.Handle);
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 #endregion
@@ -92,7 +67,7 @@ namespace MonoMac.CoreText {
 		{
 			if (path == null)
 				throw new ArgumentNullException ("path");
-			var frame = CTFramesetterCreateFrame (handle, stringRange, path.Handle,
+			var frame = CTFramesetterCreateFrame (Handle, stringRange, path.Handle,
 					frameAttributes == null ? IntPtr.Zero : frameAttributes.Dictionary.Handle);
 			if (frame == IntPtr.Zero)
 				return null;
@@ -103,7 +78,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTFramesetterGetTypesetter (IntPtr framesetter);
 		public CTTypesetter GetTypesetter ()
 		{
-			var h = CTFramesetterGetTypesetter (handle);
+			var h = CTFramesetterGetTypesetter (Handle);
 
 			if (h == IntPtr.Zero)
 				return null;
@@ -118,7 +93,7 @@ namespace MonoMac.CoreText {
 		public SizeF SuggestFrameSize (NSRange stringRange, CTFrameAttributes frameAttributes, SizeF constraints, out NSRange fitRange)
 		{
 			return CTFramesetterSuggestFrameSizeWithConstraints (
-					handle, stringRange,
+					Handle, stringRange,
 					frameAttributes == null ? IntPtr.Zero : frameAttributes.Dictionary.Handle,
 					constraints, out fitRange);
 		}

--- a/src/CoreText/CTGlyphInfo.cs
+++ b/src/CoreText/CTGlyphInfo.cs
@@ -51,42 +51,17 @@ namespace MonoMac.CoreText {
 #endregion
 
 	[Since (3,2)]
-	public class CTGlyphInfo : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTGlyphInfo : CFType {
 		internal CTGlyphInfo (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 		
-		public IntPtr Handle {
-			get {return handle;}
-		}
-
 		~CTGlyphInfo ()
 		{
 			Dispose (false);
 		}
 		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 #region Glyph Info Creation
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTGlyphInfoCreateWithGlyphName (IntPtr glyphName, IntPtr font, IntPtr baseString);
@@ -101,9 +76,9 @@ namespace MonoMac.CoreText {
 
 			using (var gn = new NSString (glyphName))
 			using (var bs = new NSString (baseString))
-				handle = CTGlyphInfoCreateWithGlyphName (gn.Handle, font.Handle, bs.Handle);
+				Handle = CTGlyphInfoCreateWithGlyphName (gn.Handle, font.Handle, bs.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -117,9 +92,9 @@ namespace MonoMac.CoreText {
 				throw ConstructorError.ArgumentNull (this, "baseString");
 
 			using (var bs = new NSString (baseString))
-				handle = CTGlyphInfoCreateWithGlyph (glyph, font.Handle, bs.Handle);
+				Handle = CTGlyphInfoCreateWithGlyph (glyph, font.Handle, bs.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -131,9 +106,9 @@ namespace MonoMac.CoreText {
 				throw ConstructorError.ArgumentNull (this, "baseString");
 
 			using (var bs = new NSString (baseString))
-				handle = CTGlyphInfoCreateWithCharacterIdentifier (cid, collection, bs.Handle);
+				Handle = CTGlyphInfoCreateWithCharacterIdentifier (cid, collection, bs.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 #endregion
@@ -143,7 +118,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTGlyphInfoGetGlyphName (IntPtr glyphInfo);
 		public string GlyphName {
 			get {
-				var cfStringRef = CTGlyphInfoGetGlyphName (handle);
+				var cfStringRef = CTGlyphInfoGetGlyphName (Handle);
 				return CFString.FetchString (cfStringRef);
 			}
 		}
@@ -151,13 +126,13 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CGFontIndex CTGlyphInfoGetCharacterIdentifier (IntPtr glyphInfo);
 		public CGFontIndex CharacterIdentifier {
-			get {return CTGlyphInfoGetCharacterIdentifier (handle);}
+			get {return CTGlyphInfoGetCharacterIdentifier (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CTCharacterCollection CTGlyphInfoGetCharacterCollection (IntPtr glyphInfo);
 		public CTCharacterCollection CharacterCollection {
-			get {return CTGlyphInfoGetCharacterCollection (handle);}
+			get {return CTGlyphInfoGetCharacterCollection (Handle);}
 		}
 #endregion
 

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -52,40 +52,15 @@ namespace MonoMac.CoreText {
     }
 	
 	[Since (3,2)]
-	public class CTLine : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTLine : CFType {
 		internal CTLine (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get { return handle; }
 		}
 
 		~CTLine ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Line Creation
@@ -96,9 +71,9 @@ namespace MonoMac.CoreText {
 			if (value == null)
 				throw ConstructorError.ArgumentNull (this, "value");
 
-			handle = CTLineCreateWithAttributedString (value.Handle);
+			Handle = CTLineCreateWithAttributedString (value.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -106,7 +81,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTLineCreateTruncatedLine (IntPtr line, double width, CTLineTruncation truncationType, IntPtr truncationToken);
 		public CTLine GetTruncatedLine (double width, CTLineTruncation truncationType, CTLine truncationToken)
 		{
-			var h = CTLineCreateTruncatedLine (handle, width, truncationType,
+			var h = CTLineCreateTruncatedLine (Handle, width, truncationType,
 					truncationToken == null ? IntPtr.Zero : truncationToken.Handle);
 			if (h == IntPtr.Zero)
 				return null;
@@ -117,7 +92,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTLineCreateJustifiedLine (IntPtr line, float justificationFactor, double justificationWidth);
 		public CTLine GetJustifiedLine (float justificationFactor, double justificationWidth)
 		{
-			var h = CTLineCreateJustifiedLine (handle, justificationFactor, justificationWidth);
+			var h = CTLineCreateJustifiedLine (Handle, justificationFactor, justificationWidth);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CTLine (h, true);
@@ -128,14 +103,14 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern int CTLineGetGlyphCount (IntPtr line);
 		public int GlyphCount {
-			get {return CTLineGetGlyphCount (handle);}
+			get {return CTLineGetGlyphCount (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTLineGetGlyphRuns (IntPtr line);
 		public CTRun[] GetGlyphRuns ()
 		{
-			var cfArrayRef = CTLineGetGlyphRuns (handle);
+			var cfArrayRef = CTLineGetGlyphRuns (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTRun [0];
 
@@ -146,14 +121,14 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern NSRange CTLineGetStringRange (IntPtr line);
 		public NSRange StringRange {
-			get {return CTLineGetStringRange (handle);}
+			get {return CTLineGetStringRange (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetPenOffsetForFlush (IntPtr line, float flushFactor, double flushWidth);
 		public double GetPenOffsetForFlush (float flushFactor, double flushWidth)
 		{
-			return CTLineGetPenOffsetForFlush (handle, flushFactor, flushWidth);
+			return CTLineGetPenOffsetForFlush (Handle, flushFactor, flushWidth);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -162,7 +137,7 @@ namespace MonoMac.CoreText {
 		{
 			if (context == null)
 				throw new ArgumentNullException ("context");
-			CTLineDraw (handle, context.Handle);
+			CTLineDraw (Handle, context.Handle);
 		}
 #endregion
 
@@ -173,7 +148,7 @@ namespace MonoMac.CoreText {
 		{
 			if (context == null)
 				throw new ArgumentNullException ("context");
-			return CTLineGetImageBounds (handle, context.Handle);
+			return CTLineGetImageBounds (Handle, context.Handle);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -181,27 +156,27 @@ namespace MonoMac.CoreText {
 		[Since (6,0)]
 		public RectangleF GetBounds (CTLineBoundsOptions options)
 		{
-			return CTLineGetBoundsWithOptions (handle, options);
+			return CTLineGetBoundsWithOptions (Handle, options);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTypographicBounds (IntPtr line, out float ascent, out float descent, out float leading);
 		public double GetTypographicBounds (out float ascent, out float descent, out float leading)
 		{
-			return CTLineGetTypographicBounds (handle, out ascent, out descent, out leading);
+			return CTLineGetTypographicBounds (Handle, out ascent, out descent, out leading);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTypographicBounds (IntPtr line, IntPtr ascent, IntPtr descent, IntPtr leading);
 		public double GetTypographicBounds ()
 		{
-			return CTLineGetTypographicBounds (handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+			return CTLineGetTypographicBounds (Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTrailingWhitespaceWidth (IntPtr line);
 		public double TrailingWhitespaceWidth {
-			get {return CTLineGetTrailingWhitespaceWidth (handle);}
+			get {return CTLineGetTrailingWhitespaceWidth (Handle);}
 		}
 #endregion
 
@@ -210,21 +185,21 @@ namespace MonoMac.CoreText {
 		static extern int CTLineGetStringIndexForPosition (IntPtr line, PointF position);
 		public int GetStringIndexForPosition (PointF position)
 		{
-			return CTLineGetStringIndexForPosition (handle, position);
+			return CTLineGetStringIndexForPosition (Handle, position);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTLineGetOffsetForStringIndex (IntPtr line, int charIndex, out float secondaryOffset);
 		public float GetOffsetForStringIndex (int charIndex, out float secondaryOffset)
 		{
-			return CTLineGetOffsetForStringIndex (handle, charIndex, out secondaryOffset);
+			return CTLineGetOffsetForStringIndex (Handle, charIndex, out secondaryOffset);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern float CTLineGetOffsetForStringIndex (IntPtr line, int charIndex, IntPtr secondaryOffset);
 		public float GetOffsetForStringIndex (int charIndex)
 		{
-			return CTLineGetOffsetForStringIndex (handle, charIndex, IntPtr.Zero);
+			return CTLineGetOffsetForStringIndex (Handle, charIndex, IntPtr.Zero);
 		}
 #endregion
 	}

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -272,40 +272,15 @@ namespace MonoMac.CoreText {
 	}
 
 	[Since (3,2)]
-	public class CTParagraphStyle : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTParagraphStyle : CFType {
 		internal CTParagraphStyle (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
 		~CTParagraphStyle ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Paragraph Style Creation
@@ -313,11 +288,11 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTParagraphStyleCreate (CTParagraphStyleSetting[] settings, int settingCount);
 		public CTParagraphStyle (CTParagraphStyleSettings settings)
 		{
-			handle = settings == null 
+			Handle = settings == null 
 				? CTParagraphStyleCreate (null, 0)
 				: CreateFromSettings (settings);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -364,7 +339,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTParagraphStyleCreateCopy (IntPtr paragraphStyle);
 		public CTParagraphStyle Clone ()
 		{
-			return new CTParagraphStyle (CTParagraphStyleCreateCopy (handle), true);
+			return new CTParagraphStyle (CTParagraphStyleCreateCopy (Handle), true);
 		}
 #endregion
 
@@ -375,7 +350,7 @@ namespace MonoMac.CoreText {
 		public unsafe CTTextTab[] GetTabStops ()
 		{
 			IntPtr cfArrayRef;
-			if (!CTParagraphStyleGetValueForSpecifier (handle, CTParagraphStyleSpecifier.TabStops, (uint) IntPtr.Size, (void*) &cfArrayRef))
+			if (!CTParagraphStyleGetValueForSpecifier (Handle, CTParagraphStyleSpecifier.TabStops, (uint) IntPtr.Size, (void*) &cfArrayRef))
 				throw new InvalidOperationException ("Unable to get property value.");
 			if (cfArrayRef == IntPtr.Zero)
 				return new CTTextTab [0];
@@ -389,7 +364,7 @@ namespace MonoMac.CoreText {
 		unsafe byte GetByteValue (CTParagraphStyleSpecifier spec)
 		{
 			byte value;
-			if (!CTParagraphStyleGetValueForSpecifier (handle, spec, sizeof (byte), &value))
+			if (!CTParagraphStyleGetValueForSpecifier (Handle, spec, sizeof (byte), &value))
 				throw new InvalidOperationException ("Unable to get property value.");
 			return value;
 		}
@@ -409,7 +384,7 @@ namespace MonoMac.CoreText {
 		unsafe float GetFloatValue (CTParagraphStyleSpecifier spec)
 		{
 			float value;
-			if (!CTParagraphStyleGetValueForSpecifier (handle, spec, sizeof (float), &value))
+			if (!CTParagraphStyleGetValueForSpecifier (Handle, spec, sizeof (float), &value))
 				throw new InvalidOperationException ("Unable to get property value.");
 			return value;
 		}

--- a/src/CoreText/CTRun.cs
+++ b/src/CoreText/CTRun.cs
@@ -44,51 +44,27 @@ namespace MonoMac.CoreText {
 	}
 
 	[Since (3,2)]
-	public class CTRun : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTRun : CFType {
 		internal CTRun (IntPtr handle)
 			: this (handle, false)
 		{
 		}
 
 		internal CTRun (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 		
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
 		~CTRun ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static void CTRunDraw (IntPtr h, IntPtr context, NSRange range);
 		public void Draw (CGContext context, NSRange range)
 		{
-			CTRunDraw (handle, context.Handle, range);
+			CTRunDraw (Handle, context.Handle, range);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -97,7 +73,7 @@ namespace MonoMac.CoreText {
 		{
 			buffer = GetBuffer (range, buffer);
 
-			CTRunGetAdvances (handle, range, buffer);
+			CTRunGetAdvances (Handle, range, buffer);
 
 			return buffer;
 		}
@@ -128,7 +104,7 @@ namespace MonoMac.CoreText {
 
 		public CTStringAttributes GetAttributes ()
 		{
-			var d = (NSDictionary) Runtime.GetNSObject (CTRunGetAttributes (handle));
+			var d = (NSDictionary) Runtime.GetNSObject (CTRunGetAttributes (Handle));
 			return d == null ? null : new CTStringAttributes (d);
 		}
 
@@ -137,7 +113,7 @@ namespace MonoMac.CoreText {
 		extern static int CTRunGetGlyphCount (IntPtr handle);
 		public int GlyphCount {
 			get {
-				return CTRunGetGlyphCount (handle);
+				return CTRunGetGlyphCount (Handle);
 			}
 		}
 
@@ -147,7 +123,7 @@ namespace MonoMac.CoreText {
 		{
 			buffer = GetBuffer (range, buffer);
 
-			CTRunGetGlyphs (handle, range, buffer);
+			CTRunGetGlyphs (Handle, range, buffer);
 
 			return buffer;
 		}
@@ -164,7 +140,7 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static RectangleF CTRunGetImageBounds (IntPtr h, IntPtr context, NSRange range);
 		public RectangleF GetImageBounds (CGContext context, NSRange range) {
-			return CTRunGetImageBounds (handle, context.Handle, range);
+			return CTRunGetImageBounds (Handle, context.Handle, range);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -173,7 +149,7 @@ namespace MonoMac.CoreText {
 		{
 			buffer = GetBuffer (range, buffer);
 
-			CTRunGetPositions (handle, range, buffer);
+			CTRunGetPositions (Handle, range, buffer);
 
 			return buffer;
 		}
@@ -191,7 +167,7 @@ namespace MonoMac.CoreText {
 		extern static CTRunStatus CTRunGetStatus (IntPtr handle);
 		public CTRunStatus Status {
 			get {
-				return CTRunGetStatus (handle);
+				return CTRunGetStatus (Handle);
 			}
 		}
 
@@ -201,7 +177,7 @@ namespace MonoMac.CoreText {
 		{
 			buffer = GetBuffer (range, buffer);
 
-			CTRunGetStringIndices (handle, range, buffer);
+			CTRunGetStringIndices (Handle, range, buffer);
 
 			return buffer;
 		}
@@ -219,7 +195,7 @@ namespace MonoMac.CoreText {
 		extern static NSRange CTRunGetStringRange (IntPtr handle);
 		public NSRange StringRange {
 			get {
-				return CTRunGetStringRange (handle);
+				return CTRunGetStringRange (Handle);
 			}
 		}
 		
@@ -227,7 +203,7 @@ namespace MonoMac.CoreText {
 		extern static CGAffineTransform CTRunGetTextMatrix (IntPtr handle);
 		public CGAffineTransform TextMatrix {
 			get {
-				return CTRunGetTextMatrix (handle);
+				return CTRunGetTextMatrix (Handle);
 			}
 		}
 		
@@ -236,13 +212,13 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static double CTRunGetTypographicBounds (IntPtr h, NSRange range, IntPtr ascent, IntPtr descent, IntPtr leading);
 		public double GetTypographicBounds (NSRange range, out float ascent, out float descent, out float leading) {
-			return CTRunGetTypographicBounds (handle, range, out ascent, out descent, out leading);
+			return CTRunGetTypographicBounds (Handle, range, out ascent, out descent, out leading);
 		}
 
 		public double GetTypographicBounds ()
 		{
 			NSRange range = new NSRange () { Location = 0, Length = 0 };
-			return CTRunGetTypographicBounds (handle, range, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+			return CTRunGetTypographicBounds (Handle, range, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 		}
 	}
 }

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -164,40 +164,15 @@ namespace MonoMac.CoreText {
 	}
 
 	[Since (3,2)]
-	public class CTRunDelegate : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTRunDelegate : CFType {
 		internal CTRunDelegate (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
 		~CTRunDelegate ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region RunDelegate Creation
@@ -209,8 +184,8 @@ namespace MonoMac.CoreText {
 			if (operations == null)
 				throw ConstructorError.ArgumentNull (this, "operations");
 
-			handle = CTRunDelegateCreate (operations.GetCallbacks (), GCHandle.ToIntPtr (operations.handle));
-			if (handle == IntPtr.Zero)
+			Handle = CTRunDelegateCreate (operations.GetCallbacks (), GCHandle.ToIntPtr (operations.handle));
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 #endregion
@@ -221,7 +196,7 @@ namespace MonoMac.CoreText {
 
 		public CTRunDelegateOperations Operations {
 			get {
-				return CTRunDelegateOperations.GetOperations (CTRunDelegateGetRefCon (handle));
+				return CTRunDelegateOperations.GetOperations (CTRunDelegateGetRefCon (Handle));
 			}
 		}
 #endregion

--- a/src/CoreText/CTTextTab.cs
+++ b/src/CoreText/CTTextTab.cs
@@ -80,40 +80,15 @@ namespace MonoMac.CoreText {
 #endregion
 
 	[Since (3,2)]
-	public class CTTextTab : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTTextTab : CFType {
 		internal CTTextTab (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
 		~CTTextTab ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Text Tab Creation
@@ -126,10 +101,10 @@ namespace MonoMac.CoreText {
 
 		public CTTextTab (CTTextAlignment alignment, double location, CTTextTabOptions options)
 		{
-			handle = CTTextTabCreate (alignment, location, 
+			Handle = CTTextTabCreate (alignment, location, 
 					options == null ? IntPtr.Zero : options.Dictionary.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 #endregion
@@ -138,20 +113,20 @@ namespace MonoMac.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CTTextAlignment CTTextTabGetAlignment (IntPtr tab);
 		public CTTextAlignment TextAlignment {
-			get {return CTTextTabGetAlignment (handle);}
+			get {return CTTextTabGetAlignment (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTTextTabGetLocation (IntPtr tab);
 		public double Location {
-			get {return CTTextTabGetLocation (handle);}
+			get {return CTTextTabGetLocation (Handle);}
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTTextTabGetOptions (IntPtr tab);
 		public CTTextTabOptions GetOptions ()
 		{
-			var options = CTTextTabGetOptions (handle);
+			var options = CTTextTabGetOptions (Handle);
 			if (options == IntPtr.Zero)
 				return null;
 			return new CTTextTabOptions (

--- a/src/CoreText/CTTypesetter.cs
+++ b/src/CoreText/CTTypesetter.cs
@@ -99,40 +99,15 @@ namespace MonoMac.CoreText {
 #endregion
 
 	[Since (3,2)]
-	public class CTTypesetter : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTTypesetter : CFType {
 		internal CTTypesetter (IntPtr handle, bool owns)
+			:base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
 		}
 
 		~CTTypesetter ()
 		{
 			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Typesetter Creation
@@ -143,9 +118,9 @@ namespace MonoMac.CoreText {
 			if (value == null)
 				throw ConstructorError.ArgumentNull (this, "value");
 
-			handle = CTTypesetterCreateWithAttributedString (value.Handle);
+			Handle = CTTypesetterCreateWithAttributedString (value.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 
@@ -156,10 +131,10 @@ namespace MonoMac.CoreText {
 			if (value == null)
 				throw ConstructorError.ArgumentNull (this, "value");
 
-			handle = CTTypesetterCreateWithAttributedStringAndOptions (value.Handle,
+			Handle = CTTypesetterCreateWithAttributedStringAndOptions (value.Handle,
 					options == null ? IntPtr.Zero : options.Dictionary.Handle);
 
-			if (handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (this);
 		}
 #endregion
@@ -169,7 +144,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTTypesetterCreateLineWithOffset (IntPtr typesetter, NSRange stringRange, double offset);
 		public CTLine GetLine (NSRange stringRange, double offset)
 		{
-			var h = CTTypesetterCreateLineWithOffset (handle, stringRange, offset);
+			var h = CTTypesetterCreateLineWithOffset (Handle, stringRange, offset);
 
 			if (h == IntPtr.Zero)
 				return null;
@@ -181,7 +156,7 @@ namespace MonoMac.CoreText {
 		static extern IntPtr CTTypesetterCreateLine (IntPtr typesetter, NSRange stringRange);
 		public CTLine GetLine (NSRange stringRange)
 		{
-			var h = CTTypesetterCreateLine (handle, stringRange);
+			var h = CTTypesetterCreateLine (Handle, stringRange);
 
 			if (h == IntPtr.Zero)
 				return null;
@@ -195,28 +170,28 @@ namespace MonoMac.CoreText {
 		static extern int CTTypesetterSuggestLineBreakWithOffset (IntPtr typesetter, int startIndex, double width, double offset);
 		public int SuggestLineBreak (int startIndex, double width, double offset)
 		{
-			return CTTypesetterSuggestLineBreakWithOffset (handle, startIndex, width, offset);
+			return CTTypesetterSuggestLineBreakWithOffset (Handle, startIndex, width, offset);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern int CTTypesetterSuggestLineBreak (IntPtr typesetter, int startIndex, double width);
 		public int SuggestLineBreak (int startIndex, double width)
 		{
-			return CTTypesetterSuggestLineBreak (handle, startIndex, width);
+			return CTTypesetterSuggestLineBreak (Handle, startIndex, width);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern int CTTypesetterSuggestClusterBreakWithOffset (IntPtr typesetter, int startIndex, double width, double offset);
 		public int SuggestClusterBreak (int startIndex, double width, double offset)
 		{
-			return CTTypesetterSuggestClusterBreakWithOffset (handle, startIndex, width, offset);
+			return CTTypesetterSuggestClusterBreakWithOffset (Handle, startIndex, width, offset);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern int CTTypesetterSuggestClusterBreak (IntPtr typesetter, int startIndex, double width);
 		public int SuggestClusterBreak (int startIndex, double width)
 		{
-			return CTTypesetterSuggestClusterBreak (handle, startIndex, width);
+			return CTTypesetterSuggestClusterBreak (Handle, startIndex, width);
 		}
 #endregion
 	}

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -33,11 +33,13 @@ namespace MonoMac.CoreVideo {
 		public static readonly NSString PlaneAlignmentKey;
 		public static readonly NSString OpenGLESCompatibilityKey;
 
-		public static readonly int CVImageBufferType;
-		
 		[DllImport (Constants.CoreVideoLibrary)]
-		extern static int CVPixelBufferGetTypeID ();
-		
+		extern static uint CVPixelBufferGetTypeID ();
+
+		public static uint TypeID {
+			get { return CVPixelBufferGetTypeID (); }
+		}
+
 		static CVPixelBuffer ()
 		{
 			var handle = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
@@ -58,7 +60,6 @@ namespace MonoMac.CoreVideo {
 				OpenGLCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferOpenGLCompatibilityKey");
 				IOSurfacePropertiesKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferIOSurfacePropertiesKey");
 				PlaneAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferPlaneAlignmentKey");
-				CVImageBufferType = CVPixelBufferGetTypeID ();
 				OpenGLESCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferOpenGLESCompatibilityKey");
 			}
 			finally {
@@ -134,7 +135,6 @@ namespace MonoMac.CoreVideo {
 		// TODO: CVPixelBufferCreateWithBytes
 		// TODO: CVPixelBufferCreateWithPlanarBytes
 		// TODO: CVPixelBufferGetExtendedPixels
-		// TODO: CVPixelBufferGetTypeID
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVPixelBufferFillExtendedPixels (IntPtr pixelBuffer);

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -85,11 +85,10 @@ namespace MonoMac.CoreVideo {
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		extern static int CVPixelBufferPoolGetTypeID ();
-		public int TypeID {
-			get {
-				return CVPixelBufferPoolGetTypeID ();
-			}
+		extern static uint CVPixelBufferPoolGetTypeID ();
+
+		public uint TypeID {
+			get { return CVPixelBufferPoolGetTypeID (); }
 		}
 
 #if !COREBUILD

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -185,7 +185,7 @@ namespace MonoMac.Foundation {
 				throw new ArgumentNullException ("key");
 
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionary.GetValue (Dictionary.Handle, str.handle));
+				return CFString.FetchString (CFDictionary.GetValue (Dictionary.Handle, str.Handle));
 			}
 		}		
 

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -64,48 +64,28 @@ namespace MonoMac.ImageIO {
 		}
 	}
 	
-	public class CGImageDestination : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CGImageDestination : CFType {
 		// invoked by marshallers
 		internal CGImageDestination (IntPtr handle) : this (handle, false)
 		{
-			this.handle = handle;
 		}
 
 		[Preserve (Conditional=true)]
-		internal CGImageDestination (IntPtr handle, bool owns)
+		internal CGImageDestination (IntPtr handle, bool owns) : base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		~CGImageDestination ()
 		{
 			Dispose (false);
 		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
 
-		public IntPtr Handle {
-			get { return handle; }
+		[DllImport (Constants.ImageIOLibrary)]
+		extern static uint CGImageDestinationGetTypeID ();
+
+		public static uint TypeID {
+			get { return CGImageDestinationGetTypeID (); }
 		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-				
-		[DllImport (Constants.ImageIOLibrary, EntryPoint="CGImageDestinationGetTypeID")]
-		public extern static int GetTypeID ();
 		
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static IntPtr CGImageDestinationCopyTypeIdentifiers ();
@@ -176,7 +156,7 @@ namespace MonoMac.ImageIO {
 		{
 			if (properties == null)
 				throw new ArgumentNullException ("properties");
-			CGImageDestinationSetProperties (handle, properties.Handle);
+			CGImageDestinationSetProperties (Handle, properties.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -186,7 +166,7 @@ namespace MonoMac.ImageIO {
 			if (image == null)
 				throw new ArgumentNullException ("image");
 			
-			CGImageDestinationAddImage (handle, image.Handle, properties == null ? IntPtr.Zero : properties.Handle);
+			CGImageDestinationAddImage (Handle, image.Handle, properties == null ? IntPtr.Zero : properties.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -197,7 +177,7 @@ namespace MonoMac.ImageIO {
 			if (source == null)
 				throw new ArgumentNullException ("source");
 			
-			CGImageDestinationAddImageFromSource (handle, source.Handle, (IntPtr) index, properties == null ? IntPtr.Zero : properties.Handle);
+			CGImageDestinationAddImageFromSource (Handle, source.Handle, (IntPtr) index, properties == null ? IntPtr.Zero : properties.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -205,7 +185,7 @@ namespace MonoMac.ImageIO {
 
 		public bool Close ()
 		{
-			var success = CGImageDestinationFinalize (handle);
+			var success = CGImageDestinationFinalize (Handle);
 			Dispose ();
 			return success;
 		}

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -128,10 +128,14 @@ namespace MonoMac.ImageIO {
 		}
 	}
 	
-	public class CGImageSource : INativeObject, IDisposable
+	public class CGImageSource : CFType
 	{
-		[DllImport (Constants.ImageIOLibrary, EntryPoint="CGImageSourceGetTypeID")]
-		public extern static int GetTypeID ();
+		[DllImport (Constants.ImageIOLibrary)]
+		extern static uint CGImageSourceGetTypeID ();
+
+		public static uint TypeID {
+			get { return CGImageSourceGetTypeID (); }
+		}
 
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static IntPtr CGImageSourceCopyTypeIdentifiers ();
@@ -141,46 +145,21 @@ namespace MonoMac.ImageIO {
 				return NSArray.StringArrayFromHandle (CGImageSourceCopyTypeIdentifiers ());
 			}
 		}
-		
-		internal IntPtr handle;
-
 		// invoked by marshallers
 		internal CGImageSource (IntPtr handle) : this (handle, false)
 		{
-			this.handle = handle;
 		}
 
 		[Preserve (Conditional=true)]
-		internal CGImageSource (IntPtr handle, bool owns)
+		internal CGImageSource (IntPtr handle, bool owns) : base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		~CGImageSource ()
 		{
 			Dispose (false);
 		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
 
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-				
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static IntPtr CGImageSourceCreateWithURL(IntPtr url, IntPtr options);
 
@@ -235,7 +214,7 @@ namespace MonoMac.ImageIO {
 		
 		public string TypeIdentifier {
 			get {
-				return NSString.FromHandle (CGImageSourceGetType (handle));
+				return NSString.FromHandle (CGImageSourceGetType (Handle));
 			}
 		}
 
@@ -244,7 +223,7 @@ namespace MonoMac.ImageIO {
 		
 		public int ImageCount {
 			get {
-				return CGImageSourceGetCount (handle);
+				return CGImageSourceGetCount (Handle);
 			}
 		}
 
@@ -254,7 +233,7 @@ namespace MonoMac.ImageIO {
 		[Advice ("Use GetProperties")]
 		public NSDictionary CopyProperties (NSDictionary dict)
 		{
-			return new NSDictionary (CGImageSourceCopyProperties (handle, dict == null ? IntPtr.Zero : dict.Handle));
+			return new NSDictionary (CGImageSourceCopyProperties (Handle, dict == null ? IntPtr.Zero : dict.Handle));
 		}
 
 		[Advice ("Use GetProperties")]
@@ -271,7 +250,7 @@ namespace MonoMac.ImageIO {
 		[Advice ("Use GetProperties")]
 		public NSDictionary CopyProperties (NSDictionary dict, int imageIndex)
 		{
-			return new NSDictionary (CGImageSourceCopyPropertiesAtIndex (handle, imageIndex, dict == null ? IntPtr.Zero : dict.Handle));
+			return new NSDictionary (CGImageSourceCopyPropertiesAtIndex (Handle, imageIndex, dict == null ? IntPtr.Zero : dict.Handle));
 		}
 
 		[Advice ("Use GetProperties")]
@@ -297,7 +276,7 @@ namespace MonoMac.ImageIO {
 		public CGImage CreateImage (int index, CGImageOptions options)
 		{
 			using (var dict = options == null ? null : options.ToDictionary ()) {
-				var ret = CGImageSourceCreateImageAtIndex (handle, index, dict == null ? IntPtr.Zero : dict.Handle);
+				var ret = CGImageSourceCreateImageAtIndex (Handle, index, dict == null ? IntPtr.Zero : dict.Handle);
 				return new CGImage (ret, true);
 			}
 		}
@@ -307,7 +286,7 @@ namespace MonoMac.ImageIO {
 		public CGImage CreateThumbnail (int index, CGImageThumbnailOptions options)
 		{
 			using (var dict = options == null ? null : options.ToDictionary ()) {
-				var ret = CGImageSourceCreateThumbnailAtIndex (handle, index, dict == null ? IntPtr.Zero : dict.Handle);
+				var ret = CGImageSourceCreateThumbnailAtIndex (Handle, index, dict == null ? IntPtr.Zero : dict.Handle);
 				return new CGImage (ret, true);
 			}
 		}
@@ -327,7 +306,7 @@ namespace MonoMac.ImageIO {
 		{
 			if (data == null)
 				throw new ArgumentNullException ("data");
-			CGImageSourceUpdateData (handle, data.Handle, final);
+			CGImageSourceUpdateData (Handle, data.Handle, final);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -337,7 +316,7 @@ namespace MonoMac.ImageIO {
 		{
 			if (provider == null)
 				throw new ArgumentNullException ("provider");
-			CGImageSourceUpdateDataProvider (handle, provider.Handle);
+			CGImageSourceUpdateDataProvider (Handle, provider.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -345,7 +324,7 @@ namespace MonoMac.ImageIO {
 		
 		public CGImageSourceStatus GetStatus ()
 		{
-			return CGImageSourceGetStatus (handle);
+			return CGImageSourceGetStatus (Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -353,7 +332,7 @@ namespace MonoMac.ImageIO {
 
 		public CGImageSourceStatus GetStatus (int index)
 		{
-			return CGImageSourceGetStatusAtIndex (handle, index);
+			return CGImageSourceGetStatusAtIndex (Handle, index);
 		}
 	}
 }

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -133,7 +133,7 @@ namespace MonoMac.ObjCRuntime {
 				return;
 			var strHandle = value == null ? IntPtr.Zero : value.Handle;
 			if (strHandle != IntPtr.Zero)
-				CFObject.CFRetain (strHandle);
+				CFType.Retain (strHandle);
 			Marshal.WriteIntPtr (indirect, strHandle);
 		}
 
@@ -144,7 +144,7 @@ namespace MonoMac.ObjCRuntime {
 				return;
 			var arrayHandle = array == null ? IntPtr.Zero : array.Handle;
 			if (arrayHandle != IntPtr.Zero)
-				CFObject.CFRetain (arrayHandle);
+				CFType.Retain (arrayHandle);
 			Marshal.WriteIntPtr (indirect, arrayHandle);
 		}
 #endif

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -589,11 +589,11 @@ namespace MonoMac.Security {
 				if ((result == SecStatusCode.Success) && (ptr != IntPtr.Zero)) {
 					int cfType = CFType.GetTypeID (ptr);
 					
-					if (cfType == SecCertificate.GetTypeID ())
+					if (cfType == SecCertificate.TypeID)
 						return new SecCertificate (ptr, true);
-					else if (cfType == SecKey.GetTypeID ())
+					else if (cfType == SecKey.TypeID)
 						return new SecKey (ptr, true);
-					else if (cfType == SecIdentity.GetTypeID ())
+					else if (cfType == SecIdentity.TypeID)
 						return new SecIdentity (ptr, true);
 					else
 						throw new Exception (String.Format ("Unexpected type: 0x{0:x}", cfType));

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -34,9 +34,7 @@ using MonoMac.CoreFoundation;
 using MonoMac.Foundation;
 
 namespace MonoMac.Security {
-	public class SecPolicy : INativeObject, IDisposable {
-		IntPtr handle;
-
+	public class SecPolicy : CFType {
 		internal SecPolicy (IntPtr handle) 
 			: this (handle, false)
 		{
@@ -44,13 +42,8 @@ namespace MonoMac.Security {
 
 		[Preserve (Conditional=true)]
 		internal SecPolicy (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
@@ -87,26 +80,12 @@ namespace MonoMac.Security {
 			Dispose (false);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
+		[DllImport (Constants.SecurityLibrary)]
+		extern static uint SecPolicyGetTypeID ();
 
-		public IntPtr Handle {
-			get { return handle; }
+		public static uint TypeID {
+			get { return SecPolicyGetTypeID (); }
 		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
-		[DllImport (Constants.SecurityLibrary, EntryPoint="SecPolicyGetTypeID")]
-		public extern static int GetTypeID ();
 
 		public static bool operator == (SecPolicy a, SecPolicy b)
 		{


### PR DESCRIPTION
There is lots of duplicated code with the core foundation type objects. This removes much of the duplication and will make binding future objects easier.
