### PR TITLE
Bind "contentsScale" for CALayer

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -258,10 +258,10 @@ namespace MonoMac.CoreAnimation {
 #if MONOMAC
 		[Export ("layoutManager")]
 		NSObject LayoutManager { get; set; }
-#else
+#endif
+
 		[Export ("contentsScale")]
 		float ContentsScale { get; set; }
-#endif
 
 		[Export ("contentsRect")]
 		RectangleF ContentsRect { get; set; }


### PR DESCRIPTION
This has been available since 10.7. It is needed to properly set the
drawing scale for a CALayer for retina devices.
